### PR TITLE
Openalex fetch example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ utilities/rdbmigration/.work
 **/.classpath
 **/.project
 **/bin/
+/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/logs/
+/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/data/
+/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/previous-harvest/

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/diff-additions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/diff-additions.config.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%    The diff tool is used to compare jena models and produce a result model which is the first model (minuend)      %>
+<%       with any matching statements in the second model (subtrahend) removed from it.                               %>
+<%    =====                                                                                                           %>
+<%    This tool produces the graph-math difference of the triples between two models. It produces a model with the    %>
+<%       triples which are in the minuend and not in the subtrahend.                                                  %>
+<%    Expressed mathematically as minuend - subtrahend = difference                                                   %>
+<%    Neither the minend nor the subtrahend are altered.                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Task>
+	<!--INPUT -->
+	    <!--MINUEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="minuend"> The model described by this config file is the model which has the data which will be in   %>
+<%     output model.                                                                                                  %>
+<%                                                                                                                    %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="minuend">harvested-data.model.xml</Param>
+	
+	<!--SUBTRAHEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="subtrahend"> The model described by this config file contains the triples which are not goning to    %>
+<%     be within the output model. If the triples match any within the minuend model then the output will be smaller  %>
+<%     than the minuend.                                                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="subtrahend">previous-harvest.model.xml</Param>
+	
+	
+    <!--DUMPFILE -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="dumptofile"> This denotes the place for a text dump file to be produced. The default format of the   %>
+<%  dumpfile is RDF/XML and is able to be added or removed from another model through the use of the transfer tool.   %>
+<%  <Param name="dumptolanguage"> This denotes the language the rdf is in. Predefined values for lang are "RDF/XML",  %>
+<%  "N-TRIPLE", "TURTLE" (or "TTL") and "N3". * null represents the default language, "RDF/XML". "RDF/XML-ABBREV" is  %>
+<%  a synonym for "RDF/XML".					  																	  %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="dumptofile">filename=data/vivo-additions.rdf.xml</Param>
+	
+	    <!--OUTPUT : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="output"> The model described by this config file is the model that will be produced which will       %>
+<%     contain the data which is in the minuend but not in the subtrahend.                                            %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="output">diff-output.model.xml</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="selective-diff"> Tells Diff to use the selectiveDiff method in execute. If any "update-types"	      %>
+<%  parameters (below) are set, this flag is implicitly set. This flag exists mostly for the case where one wishes    %>
+<%  to use selectiveDiff without specifying update types.                       				      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="selective-diff">T</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="update-types"> Each update-types entry specifies a type allowed to be updated in the process of      %>
+<%     a diff, meant primarily for creating subtraction models. Untested for addition models!		      	      %>
+<%														      %>
+<%     Specifying any type at all will cause Diff to use the selectiveDiff() method, leading to unspecified types     %>
+<%     being preserved.                                  							      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+	<!-- <Param name="update-types">http://xmlns.com/foaf/0.1/Person</Param> -->
+        <Param name="wordiness">INFO</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/diff-subtractions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/diff-subtractions.config.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%    The diff tool is used to compare jena models and produce a result model which is the first model (minuend)      %>
+<%       with any matching statements in the second model (subtrahend) removed from it.                               %>
+<%    =====                                                                                                           %>
+<%    This tool produces the graph-math difference of the triples between two models. It produces a model with the    %>
+<%       triples which are in the minuend and not in the subtrahend.                                                  %>
+<%    Expressed mathematically as minuend - subtrahend = difference                                                   %>
+<%    Neither the minend nor the subtrahend are altered.                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Task>
+	<!--INPUT -->
+	<!--MINUEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="minuend"> The model described by this config file is the model which has the data which will be in   %>
+<%     output model.                                                                                                  %>
+<%                                                                                                                    %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="minuend">previous-harvest.model.xml</Param>
+	
+    <!--SUBTRAHEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="subtrahend"> The model described by this config file contains the triples which are not goning to    %>
+<%     be within the output model. If the triples match any within the minuend model then the output will be smaller  %>
+<%     than the minuend.                                                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="subtrahend">harvested-data.model.xml</Param>
+	
+    <!--DUMPFILE -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="dumptofile"> This denotes the place for a text dump file to be produced. The default format of the   %>
+<%  dumpfile is RDF/XML and is able to be added or removed from another model through the use of the transfer tool.   %>
+<%  <Param name="dumptolanguage"> This denotes the language the rdf is in. Predefined values for lang are "RDF/XML",  %>
+<%  "N-TRIPLE", "TURTLE" (or "TTL") and "N3". * null represents the default language, "RDF/XML". "RDF/XML-ABBREV" is  %>
+<%  a synonym for "RDF/XML".					  																	  %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="dumptofile">filename=data/vivo-subtractions.rdf.xml</Param>
+	
+	<!--OUTPUT : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="output"> The model described by this config file is the model that will be produced which will       %>
+<%     contain the data which is in the minuend but not in the subtrahend.                                            %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+<!--     <Param name="output">diff-output.model.xml</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="selective-diff"> Tells Diff to use the selectiveDiff method in execute. If any "update-types"	      %>
+<%  parameters (below) are set, this flag is implicitly set. This flag exists mostly for the case where one wishes    %>
+<%  to use selectiveDiff without specifying update types.                       				      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="selective-diff">T</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="update-types"> Each update-types entry specifies a type allowed to be updated in the process of      %>
+<%     a diff, meant primarily for creating subtraction models. Untested for addition models!		      	      %>
+<%														      %>
+<%     Specifying any type at all will cause Diff to use the selectiveDiff() method, leading to unspecified types     %>
+<%     being preserved.                                  							      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+	<!-- <Param name="update-types">http://xmlns.com/foaf/0.1/Person</Param> -->
+        <Param name="wordiness">INFO</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/harvested-data.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/harvested-data.model.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  Sample input Jena model external definition                                                                         %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<!--
+    <Param name="input-config">jena-model.conf.xml</Param>
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  ===== Models =====                                                                                                  %>
+<%  type - defines which type of jena model                                                                             %>
+<%      Possible Values:                                                                                                %>
+<%          <Param name="scoreOverride">type=tdb</Param> - defines a tdb jena model                                     %>
+<%          <Param name="scoreOverride">type=sdb</Param> - defines an sdb jena model                                    %>
+<%          <Param name="scoreOverride">type=rdb</Param> - defines an rdb jena model                                    %>
+<%          <Param name="scoreOverride">type=file</Param> - defines an rdf file to use as a model                       %>
+<%                                                                                                                      %>
+<%  ===== Model Parameters =====                                                                                        %>
+<%  dbDir - the directory to store a tdb model in                                                                       %>
+<%          (only needed when type is tdb)                                                                              %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">dbDir=/absolute/path/to/dir</Param> - An absolute path to a directory on        %>
+<%              linux/unix/macosx operating systems                                                                     %>
+<%          <Param name="scoreOverride">dbDir=C:/absolute/path/to/dir</Param> - An absolute path to a directory on      %>
+<%              a windows operating system                                                                              %>
+<%          <Param name="scoreOverride">dbDir=relative/path/to/dir</Param> - A path to a directory that is relative     %>
+<%              to the folder the shell was in when this command was executed                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  file - the path to the file that contains rdf data                                                                  %>
+<%          (only needed when type is file)                                                                             %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">file=/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf    %>
+<%              file on linux/unix/macosx operating systems                                                             %>
+<%          <Param name="scoreOverride">file=C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf       %>
+<%              file on a windows operating system                                                                      %>
+<%          <Param name="scoreOverride">file=relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is      %>
+<%              relative to the folder the shell was in when this command was executed                                  %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  rdfLang - the format of the rdf in the file                                                                         %>
+<%          (optional, only used when type is file)                                                                     %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">rdfLang=RDF/XML</Param> - rdf/xml format                              %>
+<%          <Param name="scoreOverride">rdfLang=N3</Param> - n3 format                                                  %>
+<%          <Param name="scoreOverride">rdfLang=TTL</Param> - turtle/ttl format                                         %>
+<%          <Param name="scoreOverride">rdfLang=N-TRIPLE</Param> - n-triple format                                      %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbLayout - the layout to use for an sdb model                                                                       %>
+<%          (optional, only used when type is sdb)                                                                      %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">dbLayout=layout2</Param> - layout2                                    %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbType - the name of the database type (as specified by jena)                                                       %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbType=MySQL</Param> - mysql database                                           %>
+<%          <Param name="scoreOverride">dbType=H2</Param> - h2 database                                                 %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbClass - the JDBC driver class to use                                                                              %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbClass=com.mysql.jdbc.Driver</Param> - mysql database                          %>
+<%          <Param name="scoreOverride">dbClass=org.h2.Driver</Param> - h2 database                                     %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUrl - the JDBC connection url                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database               %>
+<%              see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html          %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:h2:path/to/h2/store</Param> - h2 database                            %>
+<%              see http://www.h2database.com/html/features.html#database_url                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  modelName - the named model to use                                                                                  %>
+<%          (optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )                   %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">modelName=http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>           %>
+<%          <Param name="scoreOverride">modelName=mySimpleModelName</Param>                                             %>
+<%          <Param name="scoreOverride">modelName=http://vivo.localinstitution.edu/models/my-uri-model</Param>          %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUser - the DB username to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbUser=sa</Param> - used for h2 database (the default h2 system admin login     %>
+<%          <Param name="scoreOverride">dbUser=myUser</Param>                                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbPass - the DB password to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbPass=</Param> - used for h2 database (the default h2 system admin login       %>
+<%          <Param name="scoreOverride">dbPass=myPass</Param>                                                           %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Model>
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/harvested-data/</Param>
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexFetch.bat
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexFetch.bat
@@ -1,0 +1,93 @@
+@echo off
+
+IF exist data (
+  rmdir /s /q data
+)
+
+IF exist logs (
+    rmdir /s /q logs
+)
+
+REM  set to the directory where the harvester was installed or unpacked
+REM  HARVESTER_INSTALL_DIR is set to the location of the installed harvester
+REM 	If the deb file was used to install the harvester then the
+REM 	directory should be set to /usr/share/vivo/harvester which is the
+REM 	current location associated with the deb installation.
+REM 	Since it is also possible the harvester was installed by
+REM 	uncompressing the tar.gz the setting is available to be changed
+REM 	and should agree with the installation location
+set HARVESTER_INSTALL_DIR=C:\Users\KampeB\Dev\Harvester
+set HARVEST_NAME=OpenAlex-Fetch
+FOR %%A IN (%Date:/=%) DO SET Today=%%A
+
+REM  set the CLASSPATH and HARVESTER_JAVA_OPTS to be used by all commands
+set CLASSPATH=%HARVESTER_INSTALL_DIR%/build/harvester.jar;%HARVESTER_INSTALL_DIR%/build/dependency/*
+set HARVESTER_JAVA_OPTS=-Xms1024M -Xmx2048M
+
+REM  Execute Fetch
+REM  This stage of the script is where the information is gathered together into one local
+REM 	place to facilitate the further steps of the harvest. The data is stored locally
+REM 	in a format based off of the source. The format is a form of RDF but not in the VIVO ontology
+echo Fetch from OpenAlex
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.fetch.JSONFetch -X openalexfetch.config.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Execute Translate
+REM  This is the part of the script where the input data is transformed into valid RDF
+REM    Translate will apply an xslt file to the fetched data which will result in the data
+REM    becoming valid RDF in the VIVO ontology
+echo Translate data to valid RDF
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.translate.XSLTranslator -X xsltranslator.config.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Execute Transfer to import from record handler into local temp model
+REM  From this stage on the script places the data into a Jena model. A model is a
+REM 	data storage structure similar to a database, but in RDF.
+REM  The harvester tool Transfer is used to move/add/remove/dump data in models.
+echo Transfer RDF into temporary triple store
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.transfer.Transfer -X transfer.config.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Perform an update
+REM  The harvester maintains copies of previous harvests in order to perform the same harvest twice
+REM    but only add the new statements, while removing the old statements that are no longer
+REM    contained in the input data. This is done in several steps of finding the old statements,
+REM    then the new statements, and then applying them to the Vivo main model.
+
+REM  Find Subtractions
+REM  When making the previous harvest model agree with the current harvest, the statements that exist in
+REM 	the previous harvest but not in the current harvest need to be identified for removal.
+echo Find Subtractions
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.diff.Diff -X diff-subtractions.config.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Find Additions
+REM  When making the previous harvest model agree with the current harvest, the statements that exist in
+REM 	the current harvest but not in the previous harvest need to be identified for addition.
+echo Find Additions
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.diff.Diff -X diff-additions.config.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Apply Subtractions to Previous model
+echo Apply Subtractions to Previous model
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.transfer.Transfer  -w INFO -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -m
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Apply Additions to Previous model
+echo Apply Additions to Previous model
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.transfer.Transfer  -w INFO -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Now that the changes have been applied to the previous harvest and the harvested data in vivo
+REM 	agree with the previous harvest, the changes are now applied to the vivo model.
+REM  Apply Subtractions to VIVO model
+echo Apply Subtractions to VIVO model
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.transfer.Transfer  -w INFO -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -m
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM  Apply Additions to VIVO model
+echo Apply Additions to VIVO model
+@java %HARVESTER_JAVA_OPTS% -cp %CLASSPATH% org.vivoweb.harvester.transfer.Transfer  -w INFO -o vivo.model.xml -r data/vivo-additions.rdf.xml
+ if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo Harvest completed successfully

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexFetch.sh
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexFetch.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+export HARVESTER_INSTALL_DIR=/home/kampeb/vivo-fid-bau-1-12/openalex-harvester/
+export HARVEST_NAME=OpenAlex-Harvest
+export DATE=`date +%Y-%m-%d'T'%T`
+
+# Add harvester binaries to path for execution
+# The tools within this script refer to binaries supplied within the harvester
+# Since they can be located in another directory their path should be
+# included within the classpath and the path environment variables.
+export PATH=$PATH:$HARVESTER_INSTALL_DIR/bin
+export CLASSPATH=$HARVESTER_INSTALL_DIR/build/harvester.jar:$HARVESTER_INSTALL_DIR/build/dependency/*
+
+# Exit on first error
+# The -e flag prevents the script from continuing even though a tool fails.
+# Continuing after a tool failure is undesirable since the harvested
+# data could be rendered corrupted and incompatible.
+set -e
+
+# Supply the location of the detailed log file which is generated during the script.
+# If there is an issue with a harvest, this file proves invaluable in finding
+# a solution to the problem. It has become common practice in addressing a problem
+# to request this file. The passwords and usernames are filtered out of this file
+# to prevent these logs from containing sensitive information.
+echo "Full Logging in $HARVEST_NAME.$DATE.log"
+if [ ! -d logs ]; then
+  mkdir logs
+fi
+cd logs
+touch $HARVEST_NAME.$DATE.log
+ln -sf $HARVEST_NAME.$DATE.log $HARVEST_NAME.latest.log
+cd ..
+
+#clear old data
+
+# For a fresh harvest, the removal of the previous information maintains data integrity.
+# If you are continuing a partial run or wish to use the old and already retrieved
+# data, you will want to comment out this line since it could prevent you from having
+# the required harvest data.
+rm -rf data
+
+# Execute Fetch
+# This stage of the script is where the information is gathered together into one local
+# place to facilitate the further steps of the harvest. The data is stored locally
+# in a format based off of the source. The format is a form of RDF but not in the VIVO ontology
+# The JDBCFetch tool in particular takes the data from the chosen source described in its
+# configuration XML file and places it into record set in the flat RDF directly
+# related to the rows, columns and tables described in the target database.
+echo Execute jsonfetch from OpenAlex.org
+harvester-jsonfetch -w DEBUG -X openAlexfetch.config.xml
+
+# Execute Translate
+# This is the part of the script where the input data is transformed into valid RDF
+# Translate will apply an xslt file to the fetched data which will result in the data 
+# becoming valid RDF in the VIVO ontology
+echo Execute translate
+harvester-xsltranslator -X xsltranslator.config.xml
+
+# Execute Transfer to import from record handler into local temp model
+# From this stage on the script places the data into a Jena model. A model is a
+#	data storage structure similar to a database, but in RDF.
+# The harvester tool Transfer is used to move/add/remove/dump data in models.
+# For this call on the transfer tool:
+# -s refers to the source translated records file, which was just produced by the translator step
+# -o refers to the destination model for harvested data
+# -d means that this call will also produce a text dump file in the specified location
+echo Execute initial transfer to triple store
+harvester-transfer -s translated-records.config.xml -o harvested-data.model.xml -d data/harvested-data/imported-records.rdf.xml
+
+# Perform an update
+# The harvester maintains copies of previous harvests in order to perform the same harvest twice
+#   but only add the new statements, while removing the old statements that are no longer
+#   contained in the input data. This is done in several steps of finding the old statements,
+#   then the new statements, and then applying them to the Vivo main model.
+
+# Find Subtractions
+# When making the previous harvest model agree with the current harvest, the statements that exist in
+#	the previous harvest but not in the current harvest need to be identified for removal.
+echo Find Subtractions
+harvester-diff -X diff-subtractions.config.xml
+
+# Find Additions
+# When making the previous harvest model agree with the current harvest, the statements that exist in
+#	the current harvest but not in the previous harvest need to be identified for addition.
+echo Find Additions
+harvester-diff -X diff-additions.config.xml
+
+# Apply Subtractions to Previous model
+echo Apply Subtractions to Previous model
+harvester-transfer -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -m
+# Apply Additions to Previous model
+echo  Apply Additions to Previous model
+harvester-transfer -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml
+
+# Now that the changes have been applied to the previous harvest and the harvested data in vivo
+#	agree with the previous harvest, the changes are now applied to the vivo model.
+# Apply Subtractions to VIVO
+echo Apply Subtractions to VIVO
+harvester-transfer -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -m
+# Apply Additions to VIVO for pre-1.2 versions
+echo Apply Additions to VIVO
+harvester-transfer -o vivo.model.xml -r data/vivo-additions.rdf.xml
+
+#Output some counts
+ORGS=`cat data/vivo-additions.rdf.xml | grep 'http://xmlns.com/foaf/0.1/Organization' | wc -l`
+PEOPLE=`cat data/vivo-additions.rdf.xml | grep 'http://xmlns.com/foaf/0.1/Person' | wc -l`
+POSITIONS=`cat data/vivo-additions.rdf.xml | grep 'positionForPerson' | wc -l`
+echo "Imported $ORGS organizations, $PEOPLE people, and $POSITIONS positions"
+
+echo 'Harvest completed successfully'

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexFetchPartly.sh
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexFetchPartly.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+export HARVESTER_INSTALL_DIR=/home/kampeb/vivo-fid-bau-1-12/openalex-harvester/
+export HARVEST_NAME=OpenAlex-Harvest
+export DATE=`date +%Y-%m-%d'T'%T`
+
+# Add harvester binaries to path for execution
+# The tools within this script refer to binaries supplied within the harvester
+# Since they can be located in another directory their path should be
+# included within the classpath and the path environment variables.
+export PATH=$PATH:$HARVESTER_INSTALL_DIR/bin
+export CLASSPATH=$HARVESTER_INSTALL_DIR/build/harvester.jar:$HARVESTER_INSTALL_DIR/build/dependency/*
+
+# Exit on first error
+# The -e flag prevents the script from continuing even though a tool fails.
+# Continuing after a tool failure is undesirable since the harvested
+# data could be rendered corrupted and incompatible.
+set -e
+
+# Supply the location of the detailed log file which is generated during the script.
+# If there is an issue with a harvest, this file proves invaluable in finding
+# a solution to the problem. It has become common practice in addressing a problem
+# to request this file. The passwords and usernames are filtered out of this file
+# to prevent these logs from containing sensitive information.
+echo "Full Logging in $HARVEST_NAME.$DATE.log"
+if [ ! -d logs ]; then
+  mkdir logs
+fi
+cd logs
+touch $HARVEST_NAME.$DATE.log
+ln -sf $HARVEST_NAME.$DATE.log $HARVEST_NAME.latest.log
+cd ..
+
+#clear old data
+
+# For a fresh harvest, the removal of the previous information maintains data integrity.
+# If you are continuing a partial run or wish to use the old and already retrieved
+# data, you will want to comment out this line since it could prevent you from having
+# the required harvest data.
+#rm -rf data
+
+# Execute Fetch
+# This stage of the script is where the information is gathered together into one local
+# place to facilitate the further steps of the harvest. The data is stored locally
+# in a format based off of the source. The format is a form of RDF but not in the VIVO ontology
+# The JDBCFetch tool in particular takes the data from the chosen source described in its
+# configuration XML file and places it into record set in the flat RDF directly
+# related to the rows, columns and tables described in the target database.
+#echo Execute jsonfetch from OpenAlex.org
+#harvester-jsonfetch -w DEBUG -X openAlexfetch.config.xml
+
+# Execute Translate
+# This is the part of the script where the input data is transformed into valid RDF
+# Translate will apply an xslt file to the fetched data which will result in the data 
+# becoming valid RDF in the VIVO ontology
+#echo Execute translate
+#harvester-xsltranslator -X xsltranslator.config.xml
+
+# Execute Transfer to import from record handler into local temp model
+# From this stage on the script places the data into a Jena model. A model is a
+#	data storage structure similar to a database, but in RDF.
+# The harvester tool Transfer is used to move/add/remove/dump data in models.
+# For this call on the transfer tool:
+# -s refers to the source translated records file, which was just produced by the translator step
+# -o refers to the destination model for harvested data
+# -d means that this call will also produce a text dump file in the specified location
+#echo Execute initial transfer to triple store
+#harvester-transfer -s translated-records.config.xml -o harvested-data.model.xml -d data/harvested-data/imported-records.rdf.xml
+
+# Perform an update
+# The harvester maintains copies of previous harvests in order to perform the same harvest twice
+#   but only add the new statements, while removing the old statements that are no longer
+#   contained in the input data. This is done in several steps of finding the old statements,
+#   then the new statements, and then applying them to the Vivo main model.
+
+# Find Subtractions
+# When making the previous harvest model agree with the current harvest, the statements that exist in
+#	the previous harvest but not in the current harvest need to be identified for removal.
+#echo Find Subtractions
+#harvester-diff -X diff-subtractions.config.xml
+
+# Find Additions
+# When making the previous harvest model agree with the current harvest, the statements that exist in
+#	the current harvest but not in the previous harvest need to be identified for addition.
+#echo Find Additions
+#harvester-diff -X diff-additions.config.xml
+
+# Apply Subtractions to Previous model
+#echo Apply Subtractions to Previous model
+#harvester-transfer -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -m
+# Apply Additions to Previous model
+#echo  Apply Additions to Previous model
+#harvester-transfer -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml
+
+# Now that the changes have been applied to the previous harvest and the harvested data in vivo
+#	agree with the previous harvest, the changes are now applied to the vivo model.
+# Apply Subtractions to VIVO
+echo Apply Subtractions to VIVO
+harvester-transfer -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -m
+# Apply Additions to VIVO for pre-1.2 versions
+echo Apply Additions to VIVO
+harvester-transfer -o vivo.model.xml -r data/vivo-additions.rdf.xml
+
+# Output some counts
+ORGS=`cat data/vivo-additions.rdf.xml | grep 'http://xmlns.com/foaf/0.1/Organization' | wc -l`
+PEOPLE=`cat data/vivo-additions.rdf.xml | grep 'http://xmlns.com/foaf/0.1/Person' | wc -l`
+POSITIONS=`cat data/vivo-additions.rdf.xml | grep 'positionForPerson' | wc -l`
+echo "Imported $ORGS organizations, $PEOPLE people, and $POSITIONS positions"
+
+echo 'Harvest completed successfully'

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexfetch.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexfetch.config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<config>
+    # harvesting publications from TIB – Leibniz Information Centre for Science and Technology. exchange the ROR ID to test with your institution.
+    <param name="file">https://api.openalex.org/works?filter=authorships.institutions.ror:https://ror.org/04aj4c181&amp;per-page=200&amp;mailto=forschungsatlas@tib.eu&amp;cursor=*</param>
+
+    # harvesting of publications from the subfield "Semantic Web and Ontology Develoment", should result in ca. 9-10k publications
+<!--    <param name="file">https://api.openalex.org/works?page=1&filter=primary_topic.id:t10215,publication_year:2022-2024&amp;per-page=200&amp;cursor=*</param>-->
+
+    # harvesting of publications from the journal "Quantitative Science Studies".
+<!--    <param name="file">https://api.openalex.org/works?page=1&filter=primary_location.source.id:s4210195326&amp;per-page=200&amp;mailto=forschungsatlas@tib.eu&amp;cursor=*</param>-->
+
+    <param name="output">raw-records.config.xml</param>
+    <param name="namespaceBase">http://vivo.example.com/harvest/aims_users/</param>
+    <param name="description">publication</param>
+    <param name="id">uid</param>
+    <param name="path">$.results</param>
+    <Param name="wordiness">INFO</Param>
+</config>
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openalex-to-vivo.datamap.xsl
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openalex-to-vivo.datamap.xsl
@@ -1,0 +1,1513 @@
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!-- Header information for the Style Sheet
+	The style sheet requires xmlns for each prefix you use in constructing
+	the new elements
+-->
+
+<xsl:stylesheet version = "2.0"
+                xmlns:xsl = 'http://www.w3.org/1999/XSL/Transform'
+                xmlns:rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+                xmlns:rdfs = 'http://www.w3.org/2000/01/rdf-schema#'
+                xmlns:core = 'http://vivoweb.org/ontology/core#'
+                xmlns:score = 'http://vivoweb.org/ontology/score#'
+                xmlns:foaf = 'http://xmlns.com/foaf/0.1/'
+                xmlns:bibo = 'http://purl.org/ontology/bibo/'
+                xmlns:obo = 'http://purl.obolibrary.org/obo/'
+                xmlns:vitro = 'http://vitro.mannlib.cornell.edu/ns/vitro/0.7#'
+                xmlns:vcard = 'http://www.w3.org/2006/vcard/ns#'
+                xmlns:kdsf-vivo = 'http://lod.tib.eu/onto/kdsf/'
+                xmlns:node-publication='http://vivo.example.com/harvest/aims_users/fields/publication/'
+                xmlns:fn='http://www.w3.org/2005/xpath-functions'
+                xmlns:functx='http://www.functx.com'
+                xmlns:vivo-oa='http://lod.tib.eu/onto/vivo-oa/'
+                xmlns:c4o='http://purl.org/spar/c4o/' >
+
+    <xsl:output method = "xml" indent = "yes"/>
+    <xsl:variable name = "baseURI">https://forschungsatlas.fid-bau.de/individual/</xsl:variable>
+
+    <xsl:template match = "rdf:RDF">
+        <rdf:RDF xmlns:rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+                 xmlns:rdfs = 'http://www.w3.org/2000/01/rdf-schema#'
+                 xmlns:core = 'http://vivoweb.org/ontology/core#'
+                 xmlns:score = 'http://vivoweb.org/ontology/score#'
+                 xmlns:foaf = 'http://xmlns.com/foaf/0.1/'
+                 xmlns:bibo = 'http://purl.org/ontology/bibo/'>
+            <xsl:apply-templates select = "rdf:Description" />
+        </rdf:RDF>
+    </xsl:template>
+
+<!--    <xsl:template match = "rdf:Description">-->
+<!--        <xsl:variable name = "this" select = "." />-->
+<!--        <xsl:call-template name = "t_People">-->
+<!--            <xsl:with-param name = "this" select = "$this" />-->
+<!--            <xsl:with-param name = "personid" select = "lower-case($this/db-CSV:CN)" />-->
+<!--        </xsl:call-template>-->
+<!--    </xsl:template>-->
+
+    <xsl:template match = "rdf:Description">
+        <xsl:variable name = "this" select = "." />
+        <xsl:variable name = "title" select="$this/node-publication:title" />
+        <xsl:if test="$title != ''">
+            <xsl:variable name = "doi" select = "$this/node-publication:doi" />
+            <xsl:variable name = "oaid" select="substring-after($this/node-publication:id,'org/')" />
+            <!--        <xsl:variable name = "publisher" select="$this/node-publication:host_venue/publisher"/>-->
+            <xsl:variable name = "host_organization_name" select="$this/node-publication:primary_location/source/host_organization_name"/>
+
+            <xsl:variable name="venue_id">
+                <xsl:call-template name="setVenueId">
+                    <xsl:with-param name="issn_0" select="$this/node-publication:primary_location/source/issn/issn_0"/>
+                    <xsl:with-param name="oa_id" select="substring-after($this/node-publication:primary_location/source/id,'org/')"/>
+                </xsl:call-template>
+            </xsl:variable>
+
+            <!--        <xsl:if test="$publisher !=''">-->
+            <!--            <xsl:call-template name="t_Publisher">-->
+            <!--                <xsl:with-param name="publisher" select="$publisher"/>-->
+            <!--                <xsl:with-param name="host_venue" select="$this/node-publication:host_venue"/>-->
+            <!--            </xsl:call-template>-->
+            <!--        </xsl:if>-->
+
+            <xsl:call-template name="t_PublicationVenue">
+                <!--            <xsl:with-param name="host_venue" select="$this/node-publication:host_venue"/>  &lt;!&ndash; TODO: deprecated, use primary location instead &ndash;&gt;-->
+                <xsl:with-param name="primary_location" select="$this/node-publication:primary_location"/>
+                <!--            <xsl:with-param name="pub_type" select="$this/node-publication:type"/> &lt;!&ndash;  TODO korrigieren, use type of venue!&ndash;&gt;-->
+                <!--            <xsl:with-param name="publisher" select="$publisher"/>-->
+                <xsl:with-param name="venue_id" select="$venue_id"/>
+            </xsl:call-template>
+
+            <xsl:call-template name = "t_Publications">
+                <xsl:with-param name = "this" select = "$this" />
+                <xsl:with-param name = "doi" select = "$doi" />
+                <xsl:with-param name = "oaid" select = "$oaid" />
+                <xsl:with-param name = "venue_id" select="$venue_id"/>
+            </xsl:call-template>
+            <xsl:for-each select="$this/node-publication:authorships/*">
+
+                <xsl:variable name = "affiliation" select = "raw_affiliation_string"/>
+
+                <xsl:variable name = "org_id">
+                    <xsl:call-template name = "setOrgID">
+                        <xsl:with-param name = "ror" select="substring-after(institutions/institution_0/ror,'org/')"/>
+                        <xsl:with-param name = "openAlex" select="substring-after(institutions/institution_0/id,'org/')"/>
+                    </xsl:call-template>
+                </xsl:variable>
+
+                <xsl:call-template name = "t_Author">
+                    <xsl:with-param name = "author" select = "author" />
+                    <xsl:with-param name = "org_id" select = "$org_id" />
+                    <xsl:with-param name = "doi" select = "$doi" />
+                    <xsl:with-param name = "oaid" select = "$oaid" />
+                </xsl:call-template>
+                <xsl:call-template name="t_Institution">
+                    <!--            if multiple institutions are possible the next line has to be edited to handle institutions e.g. in a for-each block-->
+                    <xsl:with-param name = "institution" select = "institutions/institution_0" />
+                    <xsl:with-param name = "org_id" select = "$org_id" />
+                    <xsl:with-param name = "affiliation" select = "$affiliation" />
+                </xsl:call-template>
+            </xsl:for-each>
+        </xsl:if>
+    </xsl:template>
+
+<!--    <xsl:template name="t_Publisher">-->
+<!--        <xsl:param name = 'publisher' />-->
+<!--        <xsl:param name = 'host_venue' />-->
+<!--        <rdf:Description rdf:about="{$baseURI}{$publisher}">-->
+<!--            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Publisher" />-->
+<!--            <rdfs:label><xsl:value-of select="$publisher"/></rdfs:label>-->
+<!--            <core:publisherOf rdf:resource="{$baseURI}{$host_venue/issn/issn_0}"/>-->
+<!--        </rdf:Description>-->
+<!--    </xsl:template>-->
+
+
+
+    <xsl:template name="t_PublicationVenue">
+        <xsl:param name = 'venue_id'/>
+        <xsl:param name = "primary_location"/>
+
+        <xsl:variable name="issn_0" select="$primary_location/source/issn/issn_0"/>
+
+        <rdf:Description rdf:about="{$baseURI}{$venue_id}">
+            <xsl:call-template name='getPublicationType'>
+                <xsl:with-param name = "pbType" select = "$primary_location/source/type" />
+            </xsl:call-template>
+
+            <xsl:if test="$issn_0 != ''"><bibo:issn><xsl:value-of select="$issn_0"/></bibo:issn></xsl:if>
+            <rdfs:label><xsl:value-of select="$primary_location/source/display_name"/></rdfs:label>
+
+            <!--            <core:publisher rdf:resource="{$baseURI}{$publisher}"/>-->
+        </rdf:Description>
+    </xsl:template>
+
+    <xsl:template name="t_Publications">
+        <xsl:param name = 'this' />
+        <xsl:param name = 'doi' />
+        <xsl:param name = 'oaid' />
+        <xsl:param name = 'venue_id'/>
+
+        <xsl:variable name="title" select="$this/node-publication:title" />
+        <xsl:variable name="publication_date" select="$this/node-publication:publication_date" />
+        <xsl:variable name="type" select="$this/node-publication:type" />
+        <xsl:variable name="type_crossref" select="$this/node-publication:type_crossref" />
+<!--        <xsl:variable name="host_venue" select="$this/node-publication:host_venue" />-->
+        <xsl:variable name="primary_location" select="$this/node-publication:primary_location"/>
+        <xsl:variable name="volume" select="$this/node-publication:biblio/volume" />
+        <xsl:variable name="issue" select="$this/node-publication:biblio/issue" />
+        <xsl:variable name="pageStart" select="$this/node-publication:biblio/first_page" />
+        <xsl:variable name="pageEnd" select="$this/node-publication:biblio/last_page" />
+        <xsl:variable name="is_oa" select="$this/node-publication:open_access/is_oa" />
+        <xsl:variable name="oa_status" select="$this/node-publication:open_access/oa_status" />
+        <xsl:variable name="cited_by_count" select="$this/node-publication:cited_by_count" />
+        <xsl:variable name="updated_date" select="$this/node-publication:updated_date" />
+
+
+<!--        Tob be added later:-->
+<!--        host_venue.issn-->
+<!--        host_venue.display_name-->
+<!--        host_venue.publisher-->
+
+<!--        <xsl:variable name="url" select="$this/node-publication:"-->
+<!--        <xsl:variable name="type" select="tibf:publication-type($this/node-publication:type)" />-->
+<!--        <xsl:variable name="type" select="$this/node-publication:type" />-->
+<!--        host_venue.type/-->
+<!--        <xsl:variable name="author" select="$this/node-publication:author" />-->
+
+        <!--    Creating a Publication   -->
+        <rdf:Description rdf:about = "{$baseURI}{$oaid}">
+            <xsl:choose>
+                <xsl:when test="$type_crossref != ''">
+                    <xsl:call-template name='getPublicationType'>
+                        <xsl:with-param name = "pbType" select = "$type_crossref" />
+                    </xsl:call-template>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:call-template name='getPublicationType'>
+                        <xsl:with-param name = "pbType" select = "$type" />
+                    </xsl:call-template>
+                </xsl:otherwise>
+            </xsl:choose>
+
+            <obo:ARG_2000028 rdf:resource="{$baseURI}vc_{$oaid}"/>
+            <rdfs:label><xsl:value-of select = "$title" /></rdfs:label> <!-- TODO add language ?-->
+
+            <xsl:if test="$doi !=''">
+                <bibo:doi><xsl:value-of select = "$doi" /></bibo:doi>
+            </xsl:if>
+
+            <core:dateTimeValue rdf:resource="{$baseURI}dtv_{$oaid}"/>
+
+            <xsl:if test="$primary_location !=''">
+                <core:hasPublicationVenue rdf:resource="{$baseURI}{$venue_id}"/>
+            </xsl:if>
+            <xsl:if test="$volume != ''">
+                <bibo:volume><xsl:value-of select="$volume" /></bibo:volume>
+            </xsl:if>
+            <xsl:if test="$issue != ''">
+                <bibo:issue><xsl:value-of select="$issue" /></bibo:issue>
+            </xsl:if>
+            <xsl:if test="$pageStart != ''">
+                <bibo:pageStart><xsl:value-of select="$pageStart" /></bibo:pageStart>
+            </xsl:if>
+            <xsl:if test="$pageEnd != ''">
+                <bibo:pageEnd><xsl:value-of select="$pageEnd" /></bibo:pageEnd>
+            </xsl:if>
+            <xsl:if test="$is_oa != ''">
+                <xsl:choose>
+                    <xsl:when test="$is_oa='true'">
+                        <vivo-oa:has_access rdf:resource="http://lod.tib.eu/onto/vivo-oa/Open_Access"/>
+                    </xsl:when>
+                    <xsl:when test="$is_oa='false'">
+                        <vivo-oa:has_access rdf:resource="http://lod.tib.eu/onto/vivo-oa/Non_Open_Access"/>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:if>
+            <xsl:if test="$oa_status != ''">
+                <xsl:choose>
+                    <xsl:when test="$oa_status='green'">
+                        <vivo-oa:has_access rdf:resource="http://lod.tib.eu/onto/vivo-oa/Open_Access_Green"/>
+                    </xsl:when>
+                    <xsl:when test="$oa_status='gold'">
+                        <vivo-oa:has_access rdf:resource="http://lod.tib.eu/onto/vivo-oa/Open_Access_Gold"/>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:if>
+            <xsl:if test="$cited_by_count != ''">
+                <c4o:hasGlobalCitationFrequency rdf:resource="{$baseURI}gcf_{$oaid}"/>
+            </xsl:if>
+
+            <xsl:for-each select="$this/node-publication:authorships/*">
+                <xsl:variable name="id" select="substring-after(author/id,'org/')"/>
+                <core:relatedBy rdf:resource="{$baseURI}authorship_{$oaid}"/>
+            </xsl:for-each>
+
+            <xsl:for-each select="$this/node-publication:concepts/*">
+                <xsl:call-template name='getConcept'>
+                    <xsl:with-param name = "concept" select = "id" />
+                </xsl:call-template>
+            </xsl:for-each>
+
+        </rdf:Description>
+
+        <!-- date time value -->
+        <xsl:if test="normalize-space( $publication_date )">
+            <rdf:Description rdf:about="{$baseURI}dtv_{$oaid}">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+                <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="$publication_date"/>T00:00:00</core:dateTime>
+                <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearMonthDayPrecision"/>
+            </rdf:Description>
+        </xsl:if>
+
+        <!-- global citation count -->
+        <xsl:if test="normalize-space( $cited_by_count )">
+            <rdf:Description rdf:about="{$baseURI}gcf_{$oaid}">
+                <rdf:type rdf:resource="http://purl.org/spar/c4o/GlobalCitationCount"/>
+                <c4o:hasGlobalCountSource rdf:resource="https://forschungsatlas01.develop.service.tib.eu/individual/n4885"/>
+                <c4o:hasGlobalCountDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="substring-before($updated_date,'.')"/></c4o:hasGlobalCountDate>
+                <c4o:hasGlobalCountValue><xsl:value-of select="$cited_by_count"/></c4o:hasGlobalCountValue>
+            </rdf:Description>
+        </xsl:if>
+
+    </xsl:template>
+
+    <!-- Create Institution -->
+    <xsl:template name="t_Institution">
+        <xsl:param name = 'institution'/>
+        <xsl:param name = "org_id"/>
+        <xsl:param name = "affiliation"/>
+        <xsl:variable name="ror" select="$institution/ror"/>
+        <xsl:variable name="label" select="$institution/display_name"/>
+
+        <xsl:variable name = "org_label" select="substring-before($affiliation, ', ')"/>
+        <xsl:variable name = "org_address" select="substring-after($affiliation, ', ')"/>
+        <xsl:variable name = "org_street" select="substring-before($org_address, ', ')"/>
+        <xsl:variable name = "org_cityCountry" select="substring-after($org_address, ', ')"/>
+        <xsl:variable name = "org_city" select="substring-before($org_cityCountry, ', ')"/>
+        <xsl:variable name = "org_country" select="substring-after($org_cityCountry, ', ')"/>
+
+        <!-- Institution -->
+        <rdf:Description rdf:about="{$baseURI}organization_{$org_id}">
+            <rdf:type rdf:resource = "http://xmlns.com/foaf/0.1/Organization"/>
+            <vitro:mostSpecificType rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+            <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$label" /></rdfs:label>
+            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/ARG_2000028"/>
+        </rdf:Description>
+
+        <!-- vcard -->
+<!--        <rdf:Description rdf:about="{$baseURI}vcard/vcard_{$org_id}">-->
+<!--            <obo:ARG_2000029 rdf:resource="{$baseURI}organization/{$org_id}"/>-->
+<!--            <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>-->
+<!--            <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>-->
+<!--            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/ARG_2000379"/>-->
+<!--            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>-->
+<!--            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>-->
+<!--            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>-->
+<!--            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>-->
+<!--            <vcard:hasAddress rdf:resource="{$baseURI}vcard/vcardAddr_{$org_id}"/>-->
+<!--        </rdf:Description>-->
+
+        <!-- vcard address -->
+<!--        <rdf:Description rdf:about="{$baseURI}vcard/vcardAddr_{$org_id}">-->
+<!--            <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>-->
+<!--            <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>-->
+<!--            <vcard:country><xsl:value-of select = "$org_country" /></vcard:country>-->
+<!--            <vcard:locality><xsl:value-of select = "substring-before($org_city, ' ')" /></vcard:locality>-->
+<!--            <vcard:postalCode><xsl:value-of select = "substring-after($org_city, ' ')" /></vcard:postalCode>-->
+<!--            <vcard:streetAddress><xsl:value-of select = "$org_street" /></vcard:streetAddress>-->
+<!--        </rdf:Description>-->
+    </xsl:template>
+
+    <!-- Create Author -->
+    <xsl:template name="t_Author">
+        <xsl:param name = 'author'/>
+        <xsl:param name = 'doi'/>
+        <xsl:param name = 'oaid'/>
+        <xsl:param name = "org_id"/>
+
+        <xsl:variable name="fullName" select="$author/display_name"/>
+        <xsl:variable name="id" select="substring-after($author/id,'org/')"/>
+        <xsl:variable name="orcid" select="replace($author/orcid,' ','')"/>
+
+        <xsl:variable name="firstName">
+            <xsl:choose>
+                <xsl:when test="fn:contains($fullName, ' ')">
+                    <xsl:value-of select="substring-before($fullName,' ')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="''"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:variable name="lastName">
+            <xsl:choose>
+                <xsl:when test="fn:contains($fullName, ' ')">
+                    <xsl:value-of select="substring-after($fullName,' ')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$fullName"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+<!--        <xsl:variable name="fullName"><xsl:value-of select = "$lastName" />, <xsl:value-of select = "$firstName" /></xsl:variable>-->
+<!--        <xsl:variable name="authorEmail" select=""/>-->
+
+
+        <!-- authorship -->
+        <rdf:Description rdf:about="{$baseURI}authorship_{$oaid}">
+            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+            <vitro:mostSpecificType rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Relationship" />
+            <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020" />
+            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001" />
+            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002" />
+            <xsl:choose>
+                <xsl:when test="$fullName">
+                    <rdfs:label>Authorship for <xsl:value-of select = "$fullName" /></rdfs:label>
+                </xsl:when>
+                <xsl:when test="$lastName">
+                    <rdfs:label>Authorship for <xsl:value-of select="$lastName" /></rdfs:label>
+                </xsl:when>
+            </xsl:choose>
+            <core:relates rdf:resource="{$baseURI}author_{$id}"/>
+            <core:relates rdf:resource="{$baseURI}{$oaid}"/>
+            <core:authorRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int"><xsl:value-of select="position()" /></core:authorRank>
+        </rdf:Description>
+
+        <!-- author -->
+        <rdf:Description rdf:about="{$baseURI}author_{$id}">
+            <rdf:type rdf:resource = "http://xmlns.com/foaf/0.1/Person"/>
+            <vitro:mostSpecificType rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+            <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$lastName" />, <xsl:value-of select = "$firstName" /></rdfs:label>
+            <obo:ARG_2000028 rdf:resource="{$baseURI}vcard_{$id}"/>
+            <core:orcidId rdf:resource="{$orcid}"/>
+            <core:relatedBy rdf:resource="{$baseURI}position/pos_{$id}"/>
+        </rdf:Description>
+
+        <!-- vcard -->
+        <rdf:Description rdf:about="{$baseURI}vcard_{$id}">
+            <obo:ARG_2000029 rdf:resource="{$baseURI}author_{$id}"/>
+            <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+            <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+            <rdf:type rdf:resource="http://purl.obolibrary.org/obo/ARG_2000379"/>
+            <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard for: <xsl:value-of select = "$fullName" /></rdfs:label>
+            <vcard:hasName rdf:resource="{$baseURI}vcardName_{$id}"/>
+<!--            <xsl:if test="normalize-space($authorEmail)" >-->
+<!--                <vcard:hasEmail rdf:resource="{$baseURI}vcard/vcardEmail_{$id}"/>-->
+<!--            </xsl:if>-->
+        </rdf:Description>
+
+        <!-- vcard name -->
+        <rdf:Description rdf:about="{$baseURI}vcardName_{$id}">
+            <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
+            <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
+            <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard name for: <xsl:value-of select = "$fullName" /></rdfs:label>
+            <vcard:givenName><xsl:value-of select = "$firstName" /></vcard:givenName>
+            <vcard:familyName><xsl:value-of select = "$lastName" /></vcard:familyName>
+        </rdf:Description>
+
+        <!-- Position-->
+        <rdf:Description rdf:about="{$baseURI}position/pos_{$id}">
+            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Position"/>
+            <core:relates rdf:resource="{$baseURI}organization_{$org_id}"/>
+        </rdf:Description>
+
+
+        <!-- vcard email -->
+<!--        <xsl:if test="normalize-space($authorEmail)" >-->
+<!--            <rdf:Description rdf:about="{$baseURI}vcard/vcardEmail_{$id}">-->
+<!--                <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Email"/>-->
+<!--                <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Work"/>-->
+<!--                <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Email"/>-->
+<!--                <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard email for: <xsl:value-of select = "$fullName" /></rdfs:label>-->
+<!--                <vcard:email rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$authorEmail" /></vcard:email>-->
+<!--            </rdf:Description>-->
+<!--        </xsl:if>-->
+    </xsl:template>
+
+    <xsl:template name="setOrgID">
+        <xsl:param name = 'ror'/>
+        <xsl:param name = 'openAlex'/>
+        <xsl:choose>
+            <xsl:when test="$ror != ''">
+                <xsl:value-of select="$ror"/>
+            </xsl:when>
+            <xsl:when test="$openAlex != ''">
+                <xsl:value-of select="$openAlex"/>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="setVenueId">
+        <xsl:param name="issn_0"/>
+        <xsl:param name="oa_id"/>
+        <xsl:choose>
+            <xsl:when test="$issn_0 != ''">
+                <xsl:value-of select="$issn_0"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$oa_id"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="getPublicationType">
+        <xsl:param name = 'pbType'>journal-article</xsl:param>
+        <xsl:variable name="up" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ '"/>
+        <xsl:variable name="lo" select="'abcdefghijklmnopqrstuvwxyz '"/>
+        <xsl:choose>
+            <xsl:when test="translate(string($pbType),$up,$lo)='article'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='book-section'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/BookSection" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='monograph'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='report-component'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentPart" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='report'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Report" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='journal-article'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='book-part'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/BookSection" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='book'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='book-set'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='reference-entry'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='proceedings-article'">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#ConferencePaper" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='journal'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Journal" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='component'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentPart" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='book-chapter'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Chapter" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='proceedings-series'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Series" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='report-series'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Series" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='proceedings'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Proceedings" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='database'">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Database" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='standard'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Standard" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='reference-book'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='posted-content'">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#BlogPosting" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='journal-issue'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Issue" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='dissertation'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Thesis" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='dataset'">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Dataset" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='book-series'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Series" />
+            </xsl:when>
+            <xsl:when test="translate(string($pbType),$up,$lo)='edited-book'">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/EditedBook" />
+            </xsl:when>
+            <xsl:otherwise>
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Document" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="getConcept">
+        <xsl:param name = 'concept'></xsl:param>
+        <xsl:choose>
+            <xsl:when test="$concept='https://openalex.org/C88230418'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21306714546_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C154611951'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11365612424_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C50128577'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11806796543_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C107054158'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21976259210_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C127454912'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21108351632_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778348673'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22049467594_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C19159745'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21657927165_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777394807'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21126014518_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C180198813'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21181970389_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777877159'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20257497633_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994410616'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20789680115_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C148803439'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21401764070_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C34447519'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11643535431_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C559116025'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20383486008_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781353297'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10656440916_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C3020690005'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21772601359_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C86432685'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10249999444_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C110872660'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11357426155_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C1631582'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10339148687_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C71864017'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10524615458_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994266286'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11227365538_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C190831278'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20339388564_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779184092'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11434895487_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C52438962'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11080617381_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C547646559'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12091564190_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776175706'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22119722052_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C82576440'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11521343997_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C153294291'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10469539698_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C3019616415'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11675558039_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2993877802'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11212646931_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C502990516'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22074562421_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C71827079'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10329727946_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C120441037'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10067875322_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C4311470'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21596097020_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2991968081'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11109695162_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779755355'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20456162297_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2988954192'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10035959677_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C54750564'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12123719627_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778852317'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12107779314_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C199733313'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11482114250_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C117455697'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21119000368_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779635184'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21466573540_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C1631582'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20342424453_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C158071213'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21400611376_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C41458344'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20892531185_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776154427'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10936780837_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776542561'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20597362058_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C127313418'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21666958044_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994544150'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10090838520_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C95831776'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20848412882_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C16678853'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11028188780_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C204983608'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10918418790_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C109948328'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10154550125_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776510970'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20246528336_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778719706'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20397061674_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C56095865'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21066445109_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C104002121'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20525772596_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C152877465'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11780355670_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C127413603'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20719591921_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C32235935'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21260135128_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778449271'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10019664563_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C143910263'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21208498100_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777351106'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21710102699_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779201158'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10257174043_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2985695025'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20272834845_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C82753439'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11520175789_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C518851703'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10071689810_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C71376074'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11810502432_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C49204034'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20044969474_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C138885662'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11068098425_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C199539241'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10077851633_1"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C1631582'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11052106899_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994464924'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21838445461_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C138816342'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11363764110_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776825979'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21734220057_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2993443034'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11599961734_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C41008148'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10548596211_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C110872660'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21378899234_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C4792198'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10585848086_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C131046424'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11803293762_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C48233174'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12088228029_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777413173'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10725821060_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C84265765'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11981733736_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2988676352'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10292232665_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C86432685'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10168537769_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992697980'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11826973867_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C44154836'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20806677380_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779732396'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10785024235_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C32763512'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21562900649_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C205649164'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10013526254_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C52622258'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21893620258_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C149782125'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11427733730_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778053677'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10082474865_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C501299471'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11550165632_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C123657996'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21144849761_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780958017'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10633584452_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C91375879'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10453205068_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C19417346'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12082792165_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C178895491'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21539000171_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C143128703'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20175620728_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C37129596'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10253523053_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781374353'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21604189794_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C71043370'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12089325758_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C190831278'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10728681156_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C41045048'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22069181738_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C165786947'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11121116874_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C28901747'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22091461619_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C542628504'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10260978363_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781440851'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10750151305_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777917351'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22140044218_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C148383697'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11386092678_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C206836424'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11194673298_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779134260'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21375822636_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776949292'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21574793358_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C130064352'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22014133992_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C61980418'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12095269328_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C36289849'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21129818147_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C95389739'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11828185802_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C88463610'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20732926524_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C144024400'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10450981137_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C83864248'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10832030476_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992537118'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21099737297_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2993267355'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21025923750_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C537397655'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21254671490_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C126255220'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20118146428_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2993624421'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10606149036_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C528095902'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10447875765_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C75586009'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22082460470_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777364373'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21275210525_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781283787'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21993371835_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C26271046'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21981049546_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C115901376'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10778940072_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780396716'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21211107111_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2991746682'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20750891397_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779576378'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11317182150_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C97053079'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20869915834_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2984309096'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20091249387_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2986442093'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20954911058_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C149923435'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20203351007_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C526734887'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10369505798_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C52119013'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10328195327_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2549261'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21174281825_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994455448'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21830386323_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2983406839'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11949182252_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C3018369621'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10000002839_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778348119'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10460242295_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C555826173'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20262631282_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C88862950'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12142364286_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C541104983'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20393980707_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C112149622'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11959378370_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C39853841'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11417381790_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C116681429'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11870070600_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781259832'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21536870954_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779201158'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20344259458_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777538416'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11900975607_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2988166257'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20671496642_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777973936'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11488656433_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C189326681'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10062549072_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994058677'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21790729232_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C15744967'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20488350687_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C74363100'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10761175854_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781137002'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11207426288_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C531593650'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21759215799_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992325636'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20441139478_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C93692415'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10930345245_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780060422'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20583726163_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C8625798'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10154313028_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994493120'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11940865504_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C105639569'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11570030183_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2985879086'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21383563223_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2987985974'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11685037446_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C39549134'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10676251851_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2908647359'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10657727406_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C33923547'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21875582790_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C118416809'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10874191971_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C110269972'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11892292587_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780328347'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11073274478_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C67141207'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10725922667_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C12404463'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22103737565_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C74294582'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20817216607_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C206139338'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10415405816_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C202565627'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10183544763_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778647717'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21363350966_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C116822448'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10875042401_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994309752'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10617488519_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C137403100'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12134883531_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777347956'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20828641775_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C94625758'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10319999407_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C18574340'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11135834099_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994141135'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20513125884_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C53571324'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11277232714_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C87427459'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11898244452_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C56666940'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21082027241_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C104151175'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20244670025_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C62649853'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21143733125_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992770910'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10734123785_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2985380958'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20513125884_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C176864760'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10973112113_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2986427349'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22067143042_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780155792'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10937505789_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992184231'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20620453615_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C49271019'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21536796218_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C23213687'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11213249961_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C177986884'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11039262486_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C10879293'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10409620888_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C18650270'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10495469870_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C154193497'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10958563611_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C48327123'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10842060339_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C180872759'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10752527142_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C82685317'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10541388936_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C548895740'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12053244692_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778302417'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10133405151_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C121017731'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11878926871_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C166957645'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11966162496_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780944931'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11022806199_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2988016980'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10249970275_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781463953'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10009542917_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778348171'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12040936856_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C160934017'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21827393480_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C7879346'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12074619444_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C165895018'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21598343907_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C70160891'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20626304665_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C33613203'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21331772638_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C16160715'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21898606269_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C58640448'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11058379816_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C139019045'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11948627224_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777171531'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11618414691_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779614062'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10075885427_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2982944804'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11288635562_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2986045029'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10959220951_1"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C76155785'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20809473087_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778451013'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11511431464_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C146278227'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10002602355_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C129047720'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10299871047_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2775999810'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11434341667_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C204441458'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10000069132_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C78600449'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20764515782_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780816530'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10533403994_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778324724'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11585251942_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C141121606'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10903273502_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780510313'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21250083827_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C99476002'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10198479869_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C53657456'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10002581604_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C44493715'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11288707643_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C3017489713'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10369569520_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C71116409'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11011596617_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C82279013'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10198817614_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C199539241'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12098934955_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C61661205'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21642257976_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C71924100'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11658781751_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780631588'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11887264842_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C70036468'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11342808204_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C61441594'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10211798536_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C17744445'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20003482335_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C125471540'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21510726611_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2994183059'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11070354222_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C104988666'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12075906186_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C118518473'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10026568203_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2984157484'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10499022259_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2988151755'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10257378828_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C19159745'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11156680953_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777967926'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11279303216_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C46312422'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20037231829_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2781469121'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20488799202_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C177002080'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10899115465_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C136264566'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12140734944_1"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776190866'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22107424836_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C508466165'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22111226377_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776081408'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21198480759_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C22787982'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20230711381_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C542127796'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10531184497_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C87690585'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20015695286_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C487182'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20345584141_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C97137747'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22069584342_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C105795698'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10705334189_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992918391'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10214691016_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2986817661'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20198006041_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C206658404'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20449714594_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C524878704'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11752249521_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C50522688'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10942292645_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C184235594'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21682841947_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C86627976'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20518217068_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C57442070'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21580520479_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C77805123'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12103338603_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C205300905'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20402156503_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C505870484'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20956479909_3"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C123157820'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20763660948_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C122098685'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20751996447_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C160934017'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21827375008_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C18918823'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20996857533_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C129216166'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21395972139_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780427980'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11848861228_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2780165032'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10417431924_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778206487'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20289324773_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C90195498'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11867594779_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C193235544'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21035536571_2"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C994546'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21349340901_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2776554220'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20655861297_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C3020591692'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20052332735_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C533735693'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20844149770_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C518936366'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11814777244_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2775835988'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11874456019_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C18903297'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20882538437_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779977313'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10971599009_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2778873432'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10998786636_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2779610281'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R22025070831_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C59427239'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R12053236887_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2777364373'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10387651247_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C158049464'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20617358207_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C514928085'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R21211660442_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C73495956'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11057543064_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C122284674'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10002372986_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2989271921'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10549101185_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C4988496'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10067168537_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2984717066'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20902199568_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2992625000'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20242136859_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C2985722716'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11819156093_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C27564746'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R20647932179_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C73555534'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R10470148014_4"/>
+            </xsl:when>
+            <xsl:when test="$concept='https://openalex.org/C190048596'">
+                <core:hasSubjectArea rdf:resource="https://terminology.fraunhofer.de/voc/raum#R11510714254_4"/>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/previous-harvest.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/previous-harvest.model.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Model>
+    <Param name="type">tdb</Param>
+    <Param name="dbDir">previous-harvest</Param>
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/raw-records.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/raw-records.config.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<RecordHandler>
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Record Sets =====																								%>
+<%	rhClass - The class for the handler for this record set																%>
+<%		Example Values:																									%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>							%>
+<%			 - to store each record as a file in a folder (specified by fileDir). NOTE: performance with				%>
+<%				TextFileRecordHandler is quite poor, but is the suggested while building and testing your				%>
+<%				script. Once the script works, switch to using a higher performance recordhandler like					%>
+<%				JDBCRecordHandler (in an h2 database) or JenaRecordHandler (in a tdb model).							%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>								%>
+<%			 - to store each record in a table in a relational database (specified with dbClass, dbUrl, dbUser,			%>
+<%				dbPass, dbTable, and dataFieldName)																		%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.JenaRecordHandler</Param>								%>
+<%			 - to store each record in a jena triple store (specified with dataFieldType, jenaConfig, and/or			%>
+<%				all the parameters for a jena model (see below)															%>
+<%																														%>
+<%	===== TextFileRecordHandler Parameters =====																		%>
+<%	fileDir - the directory in which to store the files for each record													%>
+<%		Example Values:																									%>
+<%			<Param name="fileDir">/absolute/path/to/dir</Param> - An absolute path to a directory on linux/unix/macosx	%>
+<%				operating systems																						%>
+<%			<Param name="fileDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on a windows		%>
+<%				operating system																						%>
+<%			<Param name="fileDir">relative/path/to/dir</Param> - A path to a directory that is relative to the folder	%>
+<%				the shell was in when this command was executed															%>
+<%																														%>
+<%	===== JDBCRecordHandler Parameters =====																			%>
+<%	dbClass - the JDBC driver class to use																				%>
+<%		Example Values:																									%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - for a mysql database									%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - for an h2 database											%>
+<%	===																													%>
+<%																														%>
+<%	dbUrl - the JDBC connection url																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - for a mysql database.						%>
+<%				See http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - for an h2 database.									%>
+<%				See http://www.h2database.com/html/features.html#database_url											%>
+<%	===																													%>
+<%																														%>
+<%	dbUser - the DB username to use																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	===																													%>
+<%																														%>
+<%	dbPass - the DB password to use																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%	===																													%>
+<%																														%>
+<%	dbTable - (optional) the name of the table to store data in, if non-existent will be created						%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dbTable">recordTable</Param>															%>
+<%			<Param name="dbTable">myTableName</Param>																	%>
+<%	===																													%>
+<%																														%>
+<%	dataFieldName - (optional) the name of the field to use, if table is non-existent will be created with table		%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dataFieldName">dataField</Param>														%>
+<%			<Param name="dataFieldName">myDataFieldName</Param>															%>
+<%																														%>
+<%	===== JenaRecordHandler Parameters =====																			%>
+<%	dataFieldType - (optional) the predicate to use for storing data properties											%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dataFieldType">http://vivoweb.org/harvester/rh#dataFieldType</Param>					%>
+<%			<Param name="dataFieldType">http://yourmom.com/propbase#myProp</Param>										%>
+<%	===																													%>
+<%																														%>
+<%	jenaConfig - (optional - at least one of this and/or full set of params defining a model as described in Models		%>
+<%			section below) the configuration file that describes the model in which to store data. The parameters for	%>
+<%			this config file are described in the Models section below.													%>
+<%		Example Values:																									%>
+<%			<Param name="jenaConfig">/absolute/path/to/jena-model.config.xml</Param> - An absolute path					%>
+<%				to a directory on linux/unix/macosx operating systems													%>
+<%			<Param name="jenaConfig">C:/absolute/path/to/jena-model.config.xml</Param> - An absolute					%>
+<%				path to a directory on a windows operating system														%>
+<%			<Param name="jenaConfig">relative/path/to/jena-model.config.xml</Param> - A path to a						%>
+<%				directory that is relative to the folder the shell was in when this command was executed				%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample TextFileRecordHandler																						%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/tf-rh</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JDBCRecordHandler - using h2 database and default dbTable and dataFieldName									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/h2-jdbc-rh/store</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JDBCRecordHandler - using mysql database and custom dbTable and dataFieldName								%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>
+	<Param name="dbClass">com.mysql.jdbc.Driver</Param>
+	<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param>
+	<Param name="dbUser">myUser</Param>
+	<Param name="dbPass">myPass</Param>
+	<Param name="dbTable">myTableName</Param>
+	<Param name="dataFieldName">myDataFieldName</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - just base params																			%>
+<%		(using inline model configs as below the Models section or config file as defined below)						%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JenaRecordHandler</Param>
+	<Param name="dataFieldType">http://yourmom.com/propbase#myProp</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an external model config file														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="jenaConfig">jena-model.conf.xml</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Models ===== 																									%>
+<%	type - defines which type of jena model																				%>
+<%		Possible Values:																								%>
+<%			<Param name="type">tdb</Param> - defines a tdb jena model													%>
+<%			<Param name="type">sdb</Param> - defines an sdb jena model													%>
+<%			<Param name="type">rdb</Param> - defines an rdb jena model													%>
+<%			<Param name="type">file</Param> - defines an rdf file to use as a model										%>
+<%																														%>
+<%	===== Model Parameters ===== 																						%>
+<%	checkEmpty - (optional) check if the model is empty and log a warning if it is										%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="checkEmpty">false</Param> - don't check and don't log a message						%>
+<%			<Param name="checkEmpty">true</Param> - check if empty and log a warn log message if empty					%>
+<%	=== 																												%>
+<%																														%>
+<%	dbDir - the directory to store a tdb model in 																		%>
+<%			(only needed when type is tdb)	 																			%>
+<%		Example Values:																									%>
+<%			<Param name="dbDir">/absolute/path/to/dir</Param> - An absolute path to a directory on						%>
+<%				linux/unix/macosx operating systems																		%>
+<%			<Param name="dbDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on					%>
+<%				a windows operating system																				%>
+<%			<Param name="dbDir">relative/path/to/dir</Param> - A path to a directory that is relative					%>
+<%				to the folder the shell was in when this command was executed											%>
+<%	=== 																												%>
+<%																														%>
+<%	file - the path to the file that contains rdf data 																	%>
+<%			(only needed when type is file) 																			%>
+<%		Example Values:																									%>
+<%			<Param name="file">/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf					%>
+<%				file on linux/unix/macosx operating systems																%>
+<%			<Param name="file">C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf						%>
+<%				file on a windows operating system																		%>
+<%			<Param name="file">relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is					%>
+<%				relative to the folder the shell was in when this command was executed									%>
+<%	=== 																												%>
+<%																														%>
+<%	rdfLang - the format of the rdf in the file																			%>
+<%			(optional, only used when type is file) 																	%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="rdfLang">RDF/XML</Param> - rdf/xml format											%>
+<%			<Param name="rdfLang">N3</Param> - n3 format																%>
+<%			<Param name="rdfLang">TTL</Param> - turtle/ttl format														%>
+<%			<Param name="rdfLang">N-TRIPLE</Param> - n-triple format													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbLayout - the layout to use for an sdb model 																		%>
+<%			(optional, only used when type is sdb) 																		%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="dbLayout">layout2</Param> - layout2													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbType - the name of the database type (as specified by jena) 														%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbType">MySQL</Param> - mysql database															%>
+<%			<Param name="dbType">H2</Param> - h2 database																%>
+<%	=== 																												%>
+<%																														%>
+<%	dbClass - the JDBC driver class to use 																				%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - mysql database										%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - h2 database													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUrl - the JDBC connection url 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database								%>
+<%				see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - h2 database											%>
+<%				see http://www.h2database.com/html/features.html#database_url											%>
+<%	=== 																												%>
+<%																														%>
+<%	modelName - the named model to use																					%>
+<%			(optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )					%>
+<%		Examples: 																										%>
+<%			<Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>							%>
+<%			<Param name="modelName">mySimpleModelName</Param>															%>
+<%			<Param name="modelName">http://vivo.localinstitution.edu/models/my-uri-model</Param>						%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUser - the DB username to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	=== 																												%>
+<%																														%>
+<%	dbPass - the DB password to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%																														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined tdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/tdb-jena</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined file model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">file</Param>
+	<Param name="file">data/file-jena.rdf.n3</Param>
+	<Param name="rdfLang">N3</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined rdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">rdb</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined sdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">sdb</Param>
+	<Param name="dbLayout">layout2</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/raw-records</Param>
+</RecordHandler>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/transfer.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/transfer.config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <!-- 
+    wordiness - how much should be displayed on the console when the fetch is run.  Options range from nothing at all to errors only to general
+    information to more detailed debugging information.
+    -
+    Allowable values:
+    OFF - No log information is displayed on the console.
+    ERROR - All error messages are displayed. 
+    WARN - Error and warning messages are displayed.
+    INFO - Errors, warnings, and general user information is displayed.  This is the default.
+    DEBUG - Errors, warnings, general information, and information intended for debuggers is displayed to the console.
+    TRACE - All of the above as well as even finer-grain debugging information is displayed.
+    ALL - Everything that goes into the log is displayed on the console.
+
+    Values meaningful for Transfer:
+    ERROR - All runtime errors
+    DEBUG - Warning if no output is specified
+    -->
+    <Param name="wordiness">INFO</Param>
+
+    <!-- 
+    recordHandler - relative path to the configuration file of the record handler from which we are drawing our input
+    -->
+    <Param name="recordHandler">translated-records.config.xml</Param>
+
+    <!-- 
+    output - relative path to the configuration file for the Jena model to output triples to (or to remove triples from).
+    -->
+    <Param name="output">harvested-data.model.xml</Param>
+    <Param name="dumptofile">data/harvested-data/imported-records.rdf.xml</Param>
+
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/translated-records.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/translated-records.config.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<RecordHandler>
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Record Sets =====																								%>
+<%	rhClass - The class for the handler for this record set																%>
+<%		Example Values:																									%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>							%>
+<%			 - to store each record as a file in a folder (specified by fileDir). NOTE: performance with				%>
+<%				TextFileRecordHandler is quite poor, but is the suggested while building and testing your				%>
+<%				script. Once the script works, switch to using a higher performance recordhandler like					%>
+<%				JDBCRecordHandler (in an h2 database) or JenaRecordHandler (in a tdb model).							%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>								%>
+<%			 - to store each record in a table in a relational database (specified with dbClass, dbUrl, dbUser,			%>
+<%				dbPass, dbTable, and dataFieldName)																		%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.JenaRecordHandler</Param>								%>
+<%			 - to store each record in a jena triple store (specified with dataFieldType, jenaConfig, and/or			%>
+<%				all the parameters for a jena model (see below)															%>
+<%																														%>
+<%	===== TextFileRecordHandler Parameters =====																		%>
+<%	fileDir - the directory in which to store the files for each record													%>
+<%		Example Values:																									%>
+<%			<Param name="fileDir">/absolute/path/to/dir</Param> - An absolute path to a directory on linux/unix/macosx	%>
+<%				operating systems																						%>
+<%			<Param name="fileDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on a windows		%>
+<%				operating system																						%>
+<%			<Param name="fileDir">relative/path/to/dir</Param> - A path to a directory that is relative to the folder	%>
+<%				the shell was in when this command was executed															%>
+<%																														%>
+<%	===== JDBCRecordHandler Parameters =====																			%>
+<%	dbClass - the JDBC driver class to use																				%>
+<%		Example Values:																									%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - for a mysql database									%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - for an h2 database											%>
+<%	===																													%>
+<%																														%>
+<%	dbUrl - the JDBC connection url																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - for a mysql database.						%>
+<%				See http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - for an h2 database.									%>
+<%				See http://www.h2database.com/html/features.html#database_url											%>
+<%	===																													%>
+<%																														%>
+<%	dbUser - the DB username to use																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	===																													%>
+<%																														%>
+<%	dbPass - the DB password to use																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%	===																													%>
+<%																														%>
+<%	dbTable - (optional) the name of the table to store data in, if non-existent will be created						%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dbTable">recordTable</Param>															%>
+<%			<Param name="dbTable">myTableName</Param>																	%>
+<%	===																													%>
+<%																														%>
+<%	dataFieldName - (optional) the name of the field to use, if table is non-existent will be created with table		%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dataFieldName">dataField</Param>														%>
+<%			<Param name="dataFieldName">myDataFieldName</Param>															%>
+<%																														%>
+<%	===== JenaRecordHandler Parameters =====																			%>
+<%	dataFieldType - (optional) the predicate to use for storing data properties											%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dataFieldType">http://vivoweb.org/harvester/rh#dataFieldType</Param>					%>
+<%			<Param name="dataFieldType">http://yourmom.com/propbase#myProp</Param>										%>
+<%	===																													%>
+<%																														%>
+<%	jenaConfig - (optional - at least one of this and/or full set of params defining a model as described in Models		%>
+<%			section below) the configuration file that describes the model in which to store data. The parameters for	%>
+<%			this config file are described in the Models section below.													%>
+<%		Example Values:																									%>
+<%			<Param name="jenaConfig">/absolute/path/to/jena-model.config.xml</Param> - An absolute path					%>
+<%				to a directory on linux/unix/macosx operating systems													%>
+<%			<Param name="jenaConfig">C:/absolute/path/to/jena-model.config.xml</Param> - An absolute					%>
+<%				path to a directory on a windows operating system														%>
+<%			<Param name="jenaConfig">relative/path/to/jena-model.config.xml</Param> - A path to a						%>
+<%				directory that is relative to the folder the shell was in when this command was executed				%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample TextFileRecordHandler																						%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/tf-rh</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JDBCRecordHandler - using h2 database and default dbTable and dataFieldName									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/h2-jdbc-rh/store</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JDBCRecordHandler - using mysql database and custom dbTable and dataFieldName								%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>
+	<Param name="dbClass">com.mysql.jdbc.Driver</Param>
+	<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param>
+	<Param name="dbUser">myUser</Param>
+	<Param name="dbPass">myPass</Param>
+	<Param name="dbTable">myTableName</Param>
+	<Param name="dataFieldName">myDataFieldName</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - just base params																			%>
+<%		(using inline model configs as below the Models section or config file as defined below)						%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JenaRecordHandler</Param>
+	<Param name="dataFieldType">http://yourmom.com/propbase#myProp</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an external model config file														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="jenaConfig">jena-model.conf.xml</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Models ===== 																									%>
+<%	type - defines which type of jena model																				%>
+<%		Possible Values:																								%>
+<%			<Param name="type">tdb</Param> - defines a tdb jena model													%>
+<%			<Param name="type">sdb</Param> - defines an sdb jena model													%>
+<%			<Param name="type">rdb</Param> - defines an rdb jena model													%>
+<%			<Param name="type">file</Param> - defines an rdf file to use as a model										%>
+<%																														%>
+<%	===== Model Parameters ===== 																						%>
+<%	checkEmpty - (optional) check if the model is empty and log a warning if it is										%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="checkEmpty">false</Param> - don't check and don't log a message						%>
+<%			<Param name="checkEmpty">true</Param> - check if empty and log a warn log message if empty					%>
+<%	=== 																												%>
+<%																														%>
+<%	dbDir - the directory to store a tdb model in 																		%>
+<%			(only needed when type is tdb)	 																			%>
+<%		Example Values:																									%>
+<%			<Param name="dbDir">/absolute/path/to/dir</Param> - An absolute path to a directory on						%>
+<%				linux/unix/macosx operating systems																		%>
+<%			<Param name="dbDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on					%>
+<%				a windows operating system																				%>
+<%			<Param name="dbDir">relative/path/to/dir</Param> - A path to a directory that is relative					%>
+<%				to the folder the shell was in when this command was executed											%>
+<%	=== 																												%>
+<%																														%>
+<%	file - the path to the file that contains rdf data 																	%>
+<%			(only needed when type is file) 																			%>
+<%		Example Values:																									%>
+<%			<Param name="file">/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf					%>
+<%				file on linux/unix/macosx operating systems																%>
+<%			<Param name="file">C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf						%>
+<%				file on a windows operating system																		%>
+<%			<Param name="file">relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is					%>
+<%				relative to the folder the shell was in when this command was executed									%>
+<%	=== 																												%>
+<%																														%>
+<%	rdfLang - the format of the rdf in the file																			%>
+<%			(optional, only used when type is file) 																	%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="rdfLang">RDF/XML</Param> - rdf/xml format											%>
+<%			<Param name="rdfLang">N3</Param> - n3 format																%>
+<%			<Param name="rdfLang">TTL</Param> - turtle/ttl format														%>
+<%			<Param name="rdfLang">N-TRIPLE</Param> - n-triple format													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbLayout - the layout to use for an sdb model 																		%>
+<%			(optional, only used when type is sdb) 																		%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="dbLayout">layout2</Param> - layout2													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbType - the name of the database type (as specified by jena) 														%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbType">MySQL</Param> - mysql database															%>
+<%			<Param name="dbType">H2</Param> - h2 database																%>
+<%	=== 																												%>
+<%																														%>
+<%	dbClass - the JDBC driver class to use 																				%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - mysql database										%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - h2 database													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUrl - the JDBC connection url 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database								%>
+<%				see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - h2 database											%>
+<%				see http://www.h2database.com/html/features.html#database_url											%>
+<%	=== 																												%>
+<%																														%>
+<%	modelName - the named model to use																					%>
+<%			(optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )					%>
+<%		Examples: 																										%>
+<%			<Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>							%>
+<%			<Param name="modelName">mySimpleModelName</Param>															%>
+<%			<Param name="modelName">http://vivo.localinstitution.edu/models/my-uri-model</Param>						%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUser - the DB username to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	=== 																												%>
+<%																														%>
+<%	dbPass - the DB password to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%																														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined tdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/tdb-jena</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined file model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">file</Param>
+	<Param name="file">data/file-jena.rdf.n3</Param>
+	<Param name="rdfLang">N3</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined rdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">rdb</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined sdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">sdb</Param>
+	<Param name="dbLayout">layout2</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/translated-records</Param>
+</RecordHandler>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/usage.txt
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/usage.txt
@@ -1,0 +1,20 @@
+usage: JSONFetch
+ -d,--description <NAME>                a descriptive name for the json
+                                        object [have multiple -d for more
+                                        names]
+ -f,--file <FALSE>                      file containing json
+ -h,--help                              Help Message
+ -i,--id <ID>                           a single id for the json object
+                                        [have multiple -i for more ids]
+ -n,--namespaceBase <NAMESPACE_BASE>    the base namespace to use for each
+                                        node created
+ -o,--output <CONFIG_FILE>              RecordHandler config file path
+ -O,--outputOverride <RH_PARAM=VALUE>   override the RH_PARAM of output
+                                        recordhandler using VALUE
+ -p,--path <PATH>                       a single path for the json object
+                                        [have multiple -p for more json
+                                        paths]
+ -u,--url <URL>                         url which produces json
+ -w,--wordiness <LOG_LEVEL>             Set the console log level
+ -X,--config <CONFIG_FILE>              XML Configuration File
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/vivo.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/vivo.model.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  ===== Models =====                                                                                                  %>
+<%  type - defines which type of jena model                                                                             %>
+<%      Possible Values:                                                                                                %>
+<%          <Param name="scoreOverride">type=tdb</Param> - defines a tdb jena model                                     %>
+<%          <Param name="scoreOverride">type=sdb</Param> - defines an sdb jena model                                    %>
+<%          <Param name="scoreOverride">type=rdb</Param> - defines an rdb jena model                                    %>
+<%          <Param name="scoreOverride">type=file</Param> - defines an rdf file to use as a model                       %>
+<%                                                                                                                      %>
+<%  ===== Model Parameters =====                                                                                        %>
+<%  dbDir - the directory to store a tdb model in                                                                       %>
+<%          (only needed when type is tdb)                                                                              %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">dbDir=/absolute/path/to/dir</Param> - An absolute path to a directory on        %>
+<%              linux/unix/macosx operating systems                                                                     %>
+<%          <Param name="scoreOverride">dbDir=C:/absolute/path/to/dir</Param> - An absolute path to a directory on      %>
+<%              a windows operating system                                                                              %>
+<%          <Param name="scoreOverride">dbDir=relative/path/to/dir</Param> - A path to a directory that is relative     %>
+<%              to the folder the shell was in when this command was executed                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  file - the path to the file that contains rdf data                                                                  %>
+<%          (only needed when type is file)                                                                             %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">file=/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf    %>
+<%              file on linux/unix/macosx operating systems                                                             %>
+<%          <Param name="scoreOverride">file=C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf       %>
+<%              file on a windows operating system                                                                      %>
+<%          <Param name="scoreOverride">file=relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is      %>
+<%              relative to the folder the shell was in when this command was executed                                  %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  rdfLang - the format of the rdf in the file                                                                         %>
+<%          (optional, only used when type is file)                                                                     %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">rdfLang=RDF/XML</Param> - rdf/xml format                              %>
+<%          <Param name="scoreOverride">rdfLang=N3</Param> - n3 format                                                  %>
+<%          <Param name="scoreOverride">rdfLang=TTL</Param> - turtle/ttl format                                         %>
+<%          <Param name="scoreOverride">rdfLang=N-TRIPLE</Param> - n-triple format                                      %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbLayout - the layout to use for an sdb model                                                                       %>
+<%          (optional, only used when type is sdb)                                                                      %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">dbLayout=layout2</Param> - layout2                                    %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbType - the name of the database type (as specified by jena)                                                       %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbType=MySQL</Param> - mysql database                                           %>
+<%          <Param name="scoreOverride">dbType=H2</Param> - h2 database                                                 %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbClass - the JDBC driver class to use                                                                              %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbClass=com.mysql.jdbc.Driver</Param> - mysql database                          %>
+<%          <Param name="scoreOverride">dbClass=org.h2.Driver</Param> - h2 database                                     %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUrl - the JDBC connection url                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database               %>
+<%              see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html          %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:h2:path/to/h2/store</Param> - h2 database                            %>
+<%              see http://www.h2database.com/html/features.html#database_url                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  modelName - the named model to use                                                                                  %>
+<%          (optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )                   %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">modelName=http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>           %>
+<%          <Param name="scoreOverride">modelName=mySimpleModelName</Param>                                             %>
+<%          <Param name="scoreOverride">modelName=http://vivo.localinstitution.edu/models/my-uri-model</Param>          %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUser - the DB username to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbUser=sa</Param> - used for h2 database (the default h2 system admin login     %>
+<%          <Param name="scoreOverride">dbUser=myUser</Param>                                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbPass - the DB password to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbPass=</Param> - used for h2 database (the default h2 system admin login       %>
+<%          <Param name="scoreOverride">dbPass=myPass</Param>                                                           %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Model>
+    <Param name="type">tdb</Param>
+    <Param name="dbDir">/opt/data/forschungsatlas/tdbContentModels</Param>
+    <Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/xsltranslator.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/xsltranslator.config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<Param name="wordiness">INFO</Param>
+	<!--INPUT -->
+	<Param name="input">raw-records.config.xml</Param>
+	
+	<!--OUTPUT -->
+	<Param name="output">translated-records.config.xml</Param>
+
+	<!--DATAMAP -->
+	<Param name="xslFile">openalex-to-vivo.datamap.xsl</Param>
+</Task>

--- a/src/main/java/org/vivoweb/harvester/fetch/JSONFetch.java
+++ b/src/main/java/org/vivoweb/harvester/fetch/JSONFetch.java
@@ -339,77 +339,7 @@ public class JSONFetch implements RecordStreamOrigin {
 
                     if (jsonObject.get("title") == null) {
                         itr.remove();
-                    } /*else {
-                    // scoring - for getting just relevant publications belonging to listed concepts
-                        for (int j = 0; j < conceptArray.size(); j++) {
-                            JSONObject concept = (JSONObject) conceptArray.get(j);
-                            String conceptID = (String) concept.get("id");
-                            Double score = Double.parseDouble(concept.get("score").toString());
-
-                            if (conceptID.contains("C66862320") ||
-                                    conceptID.contains("C147176958") ||
-                                    conceptID.contains("C10238366") ||
-                                    conceptID.contains("C118416809") ||
-                                    conceptID.contains("C119823426") ||
-                                    conceptID.contains("C120991184") ||
-                                    conceptID.contains("C122156500") ||
-                                    conceptID.contains("C123657996") ||
-                                    conceptID.contains("C124363303") ||
-                                    conceptID.contains("C127416549") ||
-                                    conceptID.contains("C147176958") ||
-                                    conceptID.contains("C148803439") ||
-                                    conceptID.contains("C154226666") ||
-                                    conceptID.contains("C158049464") ||
-                                    conceptID.contains("C158550234") ||
-                                    conceptID.contains("C1631582") ||
-                                    conceptID.contains("C173560066") ||
-                                    conceptID.contains("C178432105") ||
-                                    conceptID.contains("C190831278") ||
-                                    conceptID.contains("C196316656") ||
-                                    conceptID.contains("C203115093") ||
-                                    conceptID.contains("C203299862") ||
-                                    conceptID.contains("C205300905") ||
-                                    conceptID.contains("C2775926657") ||
-                                    conceptID.contains("C2776009117") ||
-                                    conceptID.contains("C2776081408") ||
-                                    conceptID.contains("C2776136241") ||
-                                    conceptID.contains("C2776161637") ||
-                                    conceptID.contains("C2776311590") ||
-                                    conceptID.contains("C2776445639") ||
-                                    conceptID.contains("C2776748203") ||
-                                    conceptID.contains("C2776825979") ||
-                                    conceptID.contains("C2777231864") ||
-                                    conceptID.contains("C2777364373") ||
-                                    conceptID.contains("C2777800518") ||
-                                    conceptID.contains("C2777831296") ||
-                                    conceptID.contains("C2778206487") ||
-                                    conceptID.contains("C2778647717") ||
-                                    conceptID.contains("C2778684775") ||
-                                    conceptID.contains("C2778753569") ||
-                                    conceptID.contains("C2778906150") ||
-                                    conceptID.contains("C2779054714") ||
-                                    conceptID.contains("C2779201158") ||
-                                    conceptID.contains("C2779265402") ||
-                                    conceptID.contains("C2779331490") ||
-                                    conceptID.contains("C2779635184") ||
-                                    conceptID.contains("C2780021121") ||
-                                    conceptID.contains("C2780113678") ||
-                                    conceptID.contains("C2780344732") ||
-                                    conceptID.contains("C2780886216") ||
-                                    conceptID.contains("C2780933643") ||
-                                    conceptID.contains("C2781052401")) {
-                                log.debug("Concept:\t\t" + concept.get("display_name"));
-                                log.debug("Concept ID:\t\t" + conceptID);
-                                log.debug("Concept score:\t" + score);
-                                if (score > relevantScore)
-                                    relevantScore = score;
-                                log.debug("Relevant score:\t" + relevantScore);
-                            }
-                        }
-                        if (relevantScore < 0.35)
-                            itr.remove();
-                    }*/
-
+                    }
                 }
 
                 for (Object o : nodes) {
@@ -580,65 +510,6 @@ public class JSONFetch implements RecordStreamOrigin {
             sb.append(">\n");
             return sb.toString();
         }
-
-//    private void arrayHandling(Object val, StringBuffer sb) {
-//        JSONArray array = (JSONArray) val;
-//
-//        sb.append("\n");
-//        Iterator arrayIterator = array.iterator();
-//        Iterator objectIterator;
-////        log.debug("val: "+ array);
-//
-//        while (arrayIterator.hasNext()) {
-//            if (!arrayIndexOpen) {
-//                arrayIndexOpen = true;
-//                sb.append("    <"+ elementNo +">\n");
-//            }
-//
-//            Object obj = arrayIterator.next();
-////            log.debug("objtype: "+ obj.getClass().getName());
-//            log.debug("val: "+ obj);
-//
-//            if (obj instanceof JSONArray) {
-//                log.debug("there is an JSON Array inside: "+ obj);
-////                arrayHandling(obj, sb);
-//            } else if (obj instanceof JSONObject) {
-//                log.debug("there is an JSON Object inside: "+ obj);
-//
-//                JSONObject jsonObject = (JSONObject) obj;
-//                objectIterator = jsonObject.keySet().iterator();
-//
-//
-//                while (objectIterator.hasNext()) {
-//                    String key = (String) objectIterator.next();
-//                    Object objVal = jsonObject.get(key);
-//                    if (objVal == null) {
-//                        objVal = "";
-//                    }
-//                    String fixedkey = key
-//                            .replaceAll(" |/","_")
-//                            .replaceAll("\\(|\\)","");
-//                    if (!Character.isDigit(fixedkey.charAt(0))) {
-//                        String field = fixedkey;
-//                        sb.append(getFieldXml(field, objVal));
-//                    }
-//                }
-//
-//
-//            } else {
-////                sb.append("        <"+i+">");
-////                sb.append(obj);
-////                sb.append("</"+i+">\n");
-////                i++;
-//            }
-//            if (arrayIndexOpen) {
-//                sb.append("    </"+ elementNo +">\n");
-//                arrayIndexOpen = false;
-//                elementNo++;
-//            }
-//        }
-//        sb.append("    ");
-//    }
 
         private void objectHandling(Object val, StringBuffer sb) {
             Iterator objectIterator;

--- a/src/main/java/org/vivoweb/harvester/fetch/JSONFetch.java
+++ b/src/main/java/org/vivoweb/harvester/fetch/JSONFetch.java
@@ -5,18 +5,18 @@
  ******************************************************************************/
 package org.vivoweb.harvester.fetch;
 
-import java.io.IOException; 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator; 
 import java.util.List; 
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONArray;
+import net.minidev.json.parser.JSONParser;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vivoweb.harvester.util.FileAide;
-import org.vivoweb.harvester.util.InitLog;
-import org.vivoweb.harvester.util.SpecialEntities;
-import org.vivoweb.harvester.util.WebAide;
+import org.vivoweb.harvester.util.*;
 import org.vivoweb.harvester.util.args.ArgDef;
 import org.vivoweb.harvester.util.args.ArgList;
 import org.vivoweb.harvester.util.args.ArgParser;
@@ -289,8 +289,9 @@ public class JSONFetch implements RecordStreamOrigin {
      * @throws IOException error getting recrords
      */
     public void execute() throws IOException {
-
+        JSONParser parser = new JSONParser();
         String jsonpath = new String();
+        List<Object> nodes = null;
 
         try {
             XMLRecordOutputStream xmlRos = xmlRosBase.clone();
@@ -298,42 +299,130 @@ public class JSONFetch implements RecordStreamOrigin {
 
 
             // Get json contents as String, check for url first then a file
-            String jsonString = new String();
+            String jsonString = null;
             if (this.strAddress == null) {
-            	System.out.println(getParser().getUsage());
-            	System.exit(1);
+                System.out.println(getParser().getUsage());
+                System.exit(1);
             }
-            if (this.strAddress.startsWith("http:")) {
-               jsonString = WebAide.getURLContents(this.strAddress);
+            if (this.strAddress.startsWith("http") && this.strAddress.contains("cursor=")) {
+                nodes = paging();
+            } else if (this.strAddress.startsWith("http") && !this.strAddress.contains("cursor=")) {
+                log.debug("URL: " + this.strAddress);
+                jsonString = WebAide.getURLContents(this.strAddress);
             } else {
-               jsonString = FileAide.getTextContent(this.strAddress);
+                jsonString = FileAide.getTextContent(this.strAddress);
             }
             //log.info(jsonString);
 
-            for (int i=0; i < this.nodeNames.length ; i++) {
+            for (int i = 0; i < this.nodeNames.length; i++) {
                 String name = this.nodeNames[i];
                 String id = this.idStrings[i];
                 jsonpath = this.pathStrings[i];
-                log.info("Using path: "+ jsonpath);
+                log.info("Using path: " + jsonpath);
                 JsonPath path = JsonPath.compile(jsonpath);
-                log.info("got jsonpath: "+ path.getPath());
-                List<Object> nodes = path.read(jsonString);
-                log.info("name: "+ name);
+                log.info("got jsonpath: " + path.getPath());
+                if (jsonString != null) {
+                    log.info(jsonString);
+                    nodes = path.read(jsonString);
+                }
+                log.info("name: " + name);
                 //log.info("id: "+ id);
                 log.info("num nodes: " + nodes.size());
                 int count = 0;
 
-                 for (Object o: nodes) {
-                    JSONObject jsonObject = (JSONObject) o;
+                Iterator itr = nodes.iterator();
+
+                while (itr.hasNext()) {
+                    Double relevantScore = 0.0;
+                    JSONObject jsonObject = (JSONObject) parser.parse(itr.next().toString());
+                    JSONArray conceptArray = (JSONArray) jsonObject.get("concepts");
+
+                    if (jsonObject.get("title") == null) {
+                        itr.remove();
+                    } /*else {
+                    // scoring - for getting just relevant publications belonging to listed concepts
+                        for (int j = 0; j < conceptArray.size(); j++) {
+                            JSONObject concept = (JSONObject) conceptArray.get(j);
+                            String conceptID = (String) concept.get("id");
+                            Double score = Double.parseDouble(concept.get("score").toString());
+
+                            if (conceptID.contains("C66862320") ||
+                                    conceptID.contains("C147176958") ||
+                                    conceptID.contains("C10238366") ||
+                                    conceptID.contains("C118416809") ||
+                                    conceptID.contains("C119823426") ||
+                                    conceptID.contains("C120991184") ||
+                                    conceptID.contains("C122156500") ||
+                                    conceptID.contains("C123657996") ||
+                                    conceptID.contains("C124363303") ||
+                                    conceptID.contains("C127416549") ||
+                                    conceptID.contains("C147176958") ||
+                                    conceptID.contains("C148803439") ||
+                                    conceptID.contains("C154226666") ||
+                                    conceptID.contains("C158049464") ||
+                                    conceptID.contains("C158550234") ||
+                                    conceptID.contains("C1631582") ||
+                                    conceptID.contains("C173560066") ||
+                                    conceptID.contains("C178432105") ||
+                                    conceptID.contains("C190831278") ||
+                                    conceptID.contains("C196316656") ||
+                                    conceptID.contains("C203115093") ||
+                                    conceptID.contains("C203299862") ||
+                                    conceptID.contains("C205300905") ||
+                                    conceptID.contains("C2775926657") ||
+                                    conceptID.contains("C2776009117") ||
+                                    conceptID.contains("C2776081408") ||
+                                    conceptID.contains("C2776136241") ||
+                                    conceptID.contains("C2776161637") ||
+                                    conceptID.contains("C2776311590") ||
+                                    conceptID.contains("C2776445639") ||
+                                    conceptID.contains("C2776748203") ||
+                                    conceptID.contains("C2776825979") ||
+                                    conceptID.contains("C2777231864") ||
+                                    conceptID.contains("C2777364373") ||
+                                    conceptID.contains("C2777800518") ||
+                                    conceptID.contains("C2777831296") ||
+                                    conceptID.contains("C2778206487") ||
+                                    conceptID.contains("C2778647717") ||
+                                    conceptID.contains("C2778684775") ||
+                                    conceptID.contains("C2778753569") ||
+                                    conceptID.contains("C2778906150") ||
+                                    conceptID.contains("C2779054714") ||
+                                    conceptID.contains("C2779201158") ||
+                                    conceptID.contains("C2779265402") ||
+                                    conceptID.contains("C2779331490") ||
+                                    conceptID.contains("C2779635184") ||
+                                    conceptID.contains("C2780021121") ||
+                                    conceptID.contains("C2780113678") ||
+                                    conceptID.contains("C2780344732") ||
+                                    conceptID.contains("C2780886216") ||
+                                    conceptID.contains("C2780933643") ||
+                                    conceptID.contains("C2781052401")) {
+                                log.debug("Concept:\t\t" + concept.get("display_name"));
+                                log.debug("Concept ID:\t\t" + conceptID);
+                                log.debug("Concept score:\t" + score);
+                                if (score > relevantScore)
+                                    relevantScore = score;
+                                log.debug("Relevant score:\t" + relevantScore);
+                            }
+                        }
+                        if (relevantScore < 0.35)
+                            itr.remove();
+                    }*/
+
+                }
+
+                for (Object o : nodes) {
+                    JSONObject jsonObject = (JSONObject) parser.parse(o.toString());
                     Iterator iter = jsonObject.keySet().iterator();
                     StringBuilder sb = new StringBuilder();
 
                     //log.info("fixedkey: "+ fixedkey);
                     StringBuilder recID = new StringBuilder();
                     recID.append("node_-_");
-                    recID.append(String.valueOf(count));
+                    recID.append(count);
 
-                    //log.trace("Creating RDF for "+name+": "+recID);
+                    log.trace("Creating RDF for "+name+": "+recID);
                     // Build RDF BEGIN
                     // Header info
                     String nodeNS = "node-" + name;
@@ -363,68 +452,289 @@ public class JSONFetch implements RecordStreamOrigin {
                         String key = (String) iter.next();
                         Object val = jsonObject.get(key);
                         if (val == null) {
-                          val = "";
+                            val = "";
                         }
                         //log.info("val type for key: "+key+ ": "+val.getClass().getName());
-                        String fixedkey = key.replaceAll(" ","_"); 
-                        String field = nodeNS + ":" + fixedkey;
-                        sb.append(getFieldXml(field, val));
+                        String fixedkey = key
+                                .replaceAll(" |/", "_")
+                                .replaceAll("\\(|\\)", "")
+                                .replaceAll("/", "_");
+                        if (!Character.isDigit(fixedkey.charAt(0)) && !fixedkey.equals("abstract_inverted_index")) {
+                            // Confident JSON node names contain "Event:A6bdb69a-e51d-42d7-bd25-62ec3c40b7e8"
+                            if (fixedkey.contains(":"))
+                                fixedkey = fixedkey.substring(fixedkey.indexOf(":") + 1);
+                            String field = nodeNS + ":" + fixedkey;
+                            sb.append(getFieldXml(field, val, fixedkey));
+                        }
                     }
-                    // Record info END
-                    sb.append("  </rdf:Description>\n");
+                        // Record info END
+                        sb.append("  </rdf:Description>\n");
 
-                    // Footer info
-                    sb.append("</rdf:RDF>");
-                    // Build RDF END
+                        // Footer info
+                        sb.append("</rdf:RDF>");
+                        // Build RDF END
 
-                    // Write RDF to RecordHandler
-                    //log.trace("Adding record: " + fixedkey + "_" + recID);
-                    //log.trace("data: "+ sb.toString());
-                    //log.info("rhOutput: "+ this.rhOutput);
-                    //log.info("recID: "+recID);
-                    this.rhOutput.addRecord(name + "_" + recID, sb.toString(), this.getClass());
-                    count++;
+                        // Write RDF to RecordHandler
+                        //log.trace("Adding record: " + fixedkey + "_" + recID);
+                        //log.trace("data: "+ sb.toString());
+                        //log.info("rhOutput: "+ this.rhOutput);
+                        //log.info("recID: "+recID);
+                        this.rhOutput.addRecord(name + "_" + recID, sb.toString(), this.getClass());
+                        count++;
+                    }
+                }
+            } catch(InvalidPathException e){
+                log.error("Invalid JsonPath: " + jsonpath);
+            } catch(Exception e){
+                log.error(e.getMessage());
+                e.printStackTrace();
+                throw new IOException(e);
+            }
+        }
+
+        private ArrayList<Object> paging() throws IOException {
+            ArrayList<Object> listdata = new ArrayList<>();
+            String cursor, url_without_cursor;
+            int per_page,count,dbTime, pages = 0, i=1;
+            String jsonString;
+            JsonPath path, metapath;
+            boolean displayed = false;
+            JSONArray resultPart = new JSONArray();
+
+            JSONObject jsonObject;
+
+//        FileWriter file = new FileWriter("openalex.json");
+//        file.write("results:");
+
+            cursor = (String) this.strAddress.subSequence(this.strAddress.indexOf("cursor=")+7, this.strAddress.length());
+            url_without_cursor = (String) this.strAddress.subSequence(0, this.strAddress.indexOf("cursor="));
+            log.debug("URL: "+this.strAddress);
+
+            metapath = JsonPath.compile("$.meta");
+
+            while (cursor != null) {
+                jsonString = WebAide.getURLContents(url_without_cursor+"cursor="+cursor);
+                jsonObject = metapath.read(jsonString);
+
+                // get next cursor till if there is a next one
+                if (jsonObject.get("next_cursor") != null)
+                    cursor = jsonObject.get("next_cursor").toString();
+                else
+                    cursor = null;
+
+//            log.debug("Next cursor: "+cursor);
+
+                // get meta informations
+                if (!displayed) {
+                    dbTime = Integer.parseInt(jsonObject.get("db_response_time_ms").toString());
+                    log.debug("DB response time [ms]: "+dbTime);
+                    per_page = Integer.parseInt(jsonObject.get("per_page").toString());
+                    log.debug("Objects per page: "+per_page);
+                    count = Integer.parseInt(jsonObject.get("count").toString());
+                    log.debug("Total amount of objects: "+count);
+                    pages = (count + per_page - 1) / per_page;
+                    displayed = true;
+                }
+
+                if (cursor != null) {
+                    log.debug("Page Number: "+i+"/"+pages);
+                    // get data
+                    path = JsonPath.compile(this.pathStrings[0]);
+                    resultPart = path.read(jsonString);
+                    for (int k=0; k<resultPart.size(); k++)
+                        listdata.add(resultPart.get(k).toString());
+                }
+                i++;
+            }
+
+            log.debug("Elements in array: "+listdata.size());
+            return listdata;
+        }
+
+
+        public String getFieldXml(String field, Object val, String fixedkey) {
+            StringBuffer sb = new StringBuffer();
+
+            log.debug("val type for field "+ field +": "+val.getClass().getName());
+            sb.append("    <");
+            sb.append(SpecialEntities.xmlEncode(field).replaceAll("/","_"));
+            sb.append(">");
+
+            // insert field value
+            if (val instanceof  JSONArray) {
+                log.debug(field+" is an array with "+((JSONArray) val).size()+" elements") ;
+                XMLTagIndexing xmlTagIndexing = new XMLTagIndexing();
+                xmlTagIndexing.setElementNo(0);
+                arrayHandlingV2(val, sb, xmlTagIndexing, fixedkey);
+            } if (val instanceof  JSONObject) {
+                log.debug(field+" is an object with "+((JSONObject) val).size()+" elements") ;
+                objectHandling(val, sb);
+            } else if (val instanceof String || val instanceof Integer){
+                sb.append(SpecialEntities.xmlEncode(val.toString().trim()
+                        .replaceAll("\u201D", "'")
+                        .replaceAll("\u201C","'")));
+            }
+            // Field END
+            sb.append("</");
+            sb.append(SpecialEntities.xmlEncode(field));
+            sb.append(">\n");
+            return sb.toString();
+        }
+
+//    private void arrayHandling(Object val, StringBuffer sb) {
+//        JSONArray array = (JSONArray) val;
+//
+//        sb.append("\n");
+//        Iterator arrayIterator = array.iterator();
+//        Iterator objectIterator;
+////        log.debug("val: "+ array);
+//
+//        while (arrayIterator.hasNext()) {
+//            if (!arrayIndexOpen) {
+//                arrayIndexOpen = true;
+//                sb.append("    <"+ elementNo +">\n");
+//            }
+//
+//            Object obj = arrayIterator.next();
+////            log.debug("objtype: "+ obj.getClass().getName());
+//            log.debug("val: "+ obj);
+//
+//            if (obj instanceof JSONArray) {
+//                log.debug("there is an JSON Array inside: "+ obj);
+////                arrayHandling(obj, sb);
+//            } else if (obj instanceof JSONObject) {
+//                log.debug("there is an JSON Object inside: "+ obj);
+//
+//                JSONObject jsonObject = (JSONObject) obj;
+//                objectIterator = jsonObject.keySet().iterator();
+//
+//
+//                while (objectIterator.hasNext()) {
+//                    String key = (String) objectIterator.next();
+//                    Object objVal = jsonObject.get(key);
+//                    if (objVal == null) {
+//                        objVal = "";
+//                    }
+//                    String fixedkey = key
+//                            .replaceAll(" |/","_")
+//                            .replaceAll("\\(|\\)","");
+//                    if (!Character.isDigit(fixedkey.charAt(0))) {
+//                        String field = fixedkey;
+//                        sb.append(getFieldXml(field, objVal));
+//                    }
+//                }
+//
+//
+//            } else {
+////                sb.append("        <"+i+">");
+////                sb.append(obj);
+////                sb.append("</"+i+">\n");
+////                i++;
+//            }
+//            if (arrayIndexOpen) {
+//                sb.append("    </"+ elementNo +">\n");
+//                arrayIndexOpen = false;
+//                elementNo++;
+//            }
+//        }
+//        sb.append("    ");
+//    }
+
+        private void objectHandling(Object val, StringBuffer sb) {
+            Iterator objectIterator;
+
+            JSONObject jsonObject = (JSONObject) val;
+            objectIterator = jsonObject.keySet().iterator();
+
+            while (objectIterator.hasNext()) {
+
+                String key = (String) objectIterator.next();
+                Object objVal = jsonObject.get(key);
+                if (objVal == null) {
+                    objVal = "";
+                }
+
+                key = key.replaceAll("/","_");
+//                    .replaceAll("\\(","_")
+//                    .replaceAll("\\)","_")
+//                    .replaceAll("'","_")
+//                    .replaceAll(",","_")
+//                    .replaceAll(".","_");
+
+                if (!Character.isDigit(key.charAt(0))) {
+
+                    log.debug("field: "+key);
+//                        sb.append(getTagName(field, objVal));
+                    sb.append(getFieldXml(key, objVal, key));
                 }
             }
-        } catch (InvalidPathException e) {
-            log.error("Invalid JsonPath: "+ jsonpath);
-        } catch(Exception e) {
-            log.error(e.getMessage());
-            e.printStackTrace();
-            throw new IOException(e);
         }
-    }
-    
-    public String getFieldXml(String field, Object val) {
-       StringBuffer sb = new StringBuffer();
-       //log.debug("val type for field "+ field +": "+val.getClass().getName());
-       sb.append("    <");
-       sb.append(SpecialEntities.xmlEncode(field));
-       sb.append(">");
 
-       // insert field value
-       if (val instanceof  JSONArray) {
-    	   JSONArray array = (JSONArray) val;
-    	   log.debug("field is an array: "+ field);
-    	   Iterator iter = array.iterator();
-    	   while (iter.hasNext()) {
-    		   Object obj = iter.next();
-               log.debug("objtype: "+ obj.getClass().getName());
-    		   log.debug("val: "+ array.toString());
-    	   }
-       } else {
-         sb.append(SpecialEntities.xmlEncode(val.toString().trim()));
-       } 
-       // Field END
-       sb.append("</");
-       sb.append(SpecialEntities.xmlEncode(field));
-       sb.append(">\n");
-       return sb.toString();
-    }
+        private void arrayHandlingV2(Object val, StringBuffer sb, XMLTagIndexing xmlTagIndexing, String fixedkey) {
+            JSONArray array = (JSONArray) val;
 
+            sb.append("\n");
+            Iterator arrayIterator = array.iterator();
 
+            log.debug("val: "+ val);
 
+            while (arrayIterator.hasNext()) {
+                Object obj = arrayIterator.next();
 
+                if (!xmlTagIndexing.isArrayIndexOpen()) {
+                    xmlTagIndexing.setArrayIndexOpen();
+                    String lastChar = fixedkey.substring(fixedkey.length() - 1);
+                    if (lastChar.equals("s"))
+                        xmlTagIndexing.setXmlTagName(StringUtils.chop(fixedkey));
+                    else
+                        xmlTagIndexing.setXmlTagName(fixedkey);
+                    sb.append("    <"+xmlTagIndexing.getXmlTagName()+"_"+ xmlTagIndexing.getElementNo() +">");
+                }
+
+//            log.debug("val: "+ obj);
+
+                if (obj instanceof JSONArray) {
+                    log.debug("there is an JSON Array inside: "+ obj);
+                    XMLTagIndexing xmlArrayIndexing = new XMLTagIndexing();
+                    xmlArrayIndexing.setElementNo(0);
+
+                    arrayHandlingV2(val, sb, xmlArrayIndexing, fixedkey);
+                } else if (obj instanceof JSONObject) {
+                    log.debug("there is an JSON Object inside: "+ obj);
+                    objectHandling(obj, sb);
+                }
+                else {
+                    sb.append(obj.toString()
+                            .replaceAll("&", "&amp;")
+                            .replaceAll("</br>","")
+                            .replaceAll("<","")
+                            .replaceAll(">",""));
+                }
+                if (xmlTagIndexing.isArrayIndexOpen()) {
+                    sb.append("</"+xmlTagIndexing.getXmlTagName()+"_"+ xmlTagIndexing.getElementNo() +">\n");
+                    xmlTagIndexing.increaseElementNo();
+                    xmlTagIndexing.setArrayIndexClosed();
+                }
+            }
+            sb.append("    ");
+        }
+
+        public String getTagName(String field, Object val) {
+            StringBuffer sb = new StringBuffer();
+            log.debug("val type for tag "+ field +": "+val.getClass().getName());
+            sb.append("    <");
+            sb.append(SpecialEntities.xmlEncode(field));
+            sb.append(">");
+
+            // insert field value
+            sb.append(SpecialEntities.xmlEncode(val.toString().trim()));
+
+            // Field END
+            sb.append("</");
+            sb.append(SpecialEntities.xmlEncode(field));
+            sb.append(">\n");
+            return sb.toString();
+        }
 
     @Override
     public void writeRecord(String id, String data) throws IOException {

--- a/src/main/java/org/vivoweb/harvester/util/XMLTagIndexing.java
+++ b/src/main/java/org/vivoweb/harvester/util/XMLTagIndexing.java
@@ -1,0 +1,40 @@
+package org.vivoweb.harvester.util;
+
+public class XMLTagIndexing {
+
+    private String xmlTagName = null;
+    private int elementNo = 0;
+    private boolean arrayIndexOpen = false;
+
+    public String getXmlTagName() {
+        return xmlTagName;
+    }
+
+    public void setXmlTagName(String tagName) {
+        this.xmlTagName = tagName;
+    }
+
+    public int getElementNo() {
+        return elementNo;
+    }
+
+    public void setElementNo(int elementNo) {
+        this.elementNo = elementNo;
+    }
+
+    public void increaseElementNo() {
+        this.elementNo++;
+    }
+
+    public boolean isArrayIndexOpen() {
+        return arrayIndexOpen;
+    }
+
+    public void setArrayIndexOpen() {
+        this.arrayIndexOpen = true;
+    }
+
+    public void setArrayIndexClosed() {
+        this.arrayIndexOpen = false;
+    }
+}


### PR DESCRIPTION
Added an example of fetching publication metadata from Openalex based on the JSON fetch.
Three example queries are available in example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openAlexfetch.config.xml. Choose one for first test or modify it to fit to your needs.

OpenAlex fetch is already used in the Research Atlas: https://forschungsatlas.fid-bau.de/events

Namespace in example-scripts/bash-scripts/full-harvest-examples/1.13-1.15-examples/example-openalex/openalex-to-vivo.datamap.xsl needs to be adjusted according to your settings in runtime.properties:
<xsl:variable name = "baseURI">https://forschungsatlas.fid-bau.de/individual/</xsl:variable>

JSONFetch.java was extended to be capable of handling nested object. Also some filtering for unwanted characters was added to avoid problems with the XSLTranslator (javax.xml.transform)

Closes #56 