### PR TITLE
Dspace Harvest

### DIFF
--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/changenamespace-all.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/changenamespace-all.config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<!--INPUT -->
+	<Param name="inputModel">harvested-data.model.xml</Param>
+	
+	<!--  VIVO -->
+	<Param name="vivoModel">vivo.model.xml</Param>
+	
+	<!--  OPTIONS -->
+	<Param name="oldNamespace">http://vivo.example.com/harvest</Param>
+	<!-- <Param name="newNamespace">http://vivo.cornell.edu/individual/</Param> -->
+	<Param name="newNamespace">http://localhost:8080/vivo-1.15/individual/</Param>
+        <Param name="wordiness">INFO</Param> 
+
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/diff-additions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/diff-additions.config.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%    The diff tool is used to compare jena models and produce a result model which is the first model (minuend)      %>
+<%       with any matching statements in the second model (subtrahend) removed from it.                               %>
+<%    =====                                                                                                           %>
+<%    This tool produces the graph-math difference of the triples between two models. It produces a model with the    %>
+<%       triples which are in the minuend and not in the subtrahend.                                                  %>
+<%    Expressed mathematically as minuend - subtrahend = difference                                                   %>
+<%    Neither the minend nor the subtrahend are altered.                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Task>
+	<!--INPUT -->
+	    <!--MINUEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="minuend"> The model described by this config file is the model which has the data which will be in   %>
+<%     output model.                                                                                                  %>
+<%                                                                                                                    %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="minuend">harvested-data.model.xml</Param>
+
+	<!--VIVO -->
+		<!--SUBTRAHEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="subtrahend"> The model described by this config file contains the triples which are not goning to    %>
+<%     be within the output model. If the triples match any within the minuend model then the output will be smaller  %>
+<%     than the minuend.                                                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="subtrahend">previous-harvest.model.xml</Param>
+	
+	<!-- OPTIONS -->
+	    <!--DUMPFILE -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="dumptofile"> This denotes the place for a text dump file to be produced. The default format of the   %>
+<%  dumpfile is RDF/XML and is able to be added or removed from another model through the use of the transfer tool.   %>
+<%  <Param name="dumptolanguage"> This denotes the language the rdf is in. Predefined values for lang are "RDF/XML",  %>
+<%  "N-TRIPLE", "TURTLE" (or "TTL") and "N3". * null represents the default language, "RDF/XML". "RDF/XML-ABBREV" is  %>
+<%  a synonym for "RDF/XML".					  																	  %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="dumptofile">xmlrdf=data/vivo-additions.rdf.xml</Param>
+	<Param name="dumptolanguage">xmlrdf=RDF/XML</Param>
+	<Param name="dumptofile">ntriple=data/vivo-ntriple-additions.xml</Param>
+	<Param name="dumptolanguage">ntriple=N-TRIPLE</Param>
+
+	<!--OUTPUT : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="output"> The model described by this config file is the model that will be produced which will       %>
+<%     contain the data which is in the minuend but not in the subtrahend.                                            %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="output">diff-output.model.xml</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="selective-diff"> Tells Diff to use the selectiveDiff method in execute. If any "update-types"	      %>
+<%  parameters (below) are set, this flag is implicitly set. This flag exists mostly for the case where one wishes    %>
+<%  to use selectiveDiff without specifying update types.                       				      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="selective-diff">T</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="update-types"> Each update-types entry specifies a type allowed to be updated in the process of      %>
+<%     a diff, meant primarily for creating subtraction models. Untested for addition models!		      	      %>
+<%														      %>
+<%     Specifying any type at all will cause Diff to use the selectiveDiff() method, leading to unspecified types     %>
+<%     being preserved.                                  							      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+	<!-- <Param name="update-types">http://xmlns.com/foaf/0.1/Person</Param> -->
+        <Param name="wordiness">INFO</Param> 
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/diff-subtractions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/diff-subtractions.config.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%    The diff tool is used to compare jena models and produce a result model which is the first model (minuend)      %>
+<%       with any matching statements in the second model (subtrahend) removed from it.                               %>
+<%    =====                                                                                                           %>
+<%    This tool produces the graph-math difference of the triples between two models. It produces a model with the    %>
+<%       triples which are in the minuend and not in the subtrahend.                                                  %>
+<%    Expressed mathematically as minuend - subtrahend = difference                                                   %>
+<%    Neither the minend nor the subtrahend are altered.                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Task>
+	<!--INPUT -->
+	<!--MINUEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="minuend"> The model described by this config file is the model which has the data which will be in   %>
+<%     output model.                                                                                                  %>
+<%                                                                                                                    %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="minuend">previous-harvest.model.xml</Param>
+
+	<!--VIVO -->
+	    <!--SUBTRAHEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="subtrahend"> The model described by this config file contains the triples which are not goning to    %>
+<%     be within the output model. If the triples match any within the minuend model then the output will be smaller  %>
+<%     than the minuend.                                                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="subtrahend">harvested-data.model.xml</Param>
+
+	<!-- OPTIONS -->
+	    <!--DUMPFILE -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="dumptofile"> This denotes the place for a text dump file to be produced. The default format of the   %>
+<%  dumpfile is RDF/XML and is able to be added or removed from another model through the use of the transfer tool.   %>
+<%  <Param name="dumptolanguage"> This denotes the language the rdf is in. Predefined values for lang are "RDF/XML",  %>
+<%  "N-TRIPLE", "TURTLE" (or "TTL") and "N3". * null represents the default language, "RDF/XML". "RDF/XML-ABBREV" is  %>
+<%  a synonym for "RDF/XML".					  																	  %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="dumptofile">xmlrdf=data/vivo-subtractions.rdf.xml</Param>
+	<Param name="dumptofile">ntriple=data/vivo-ntriple-subtractions.xml</Param>
+	<Param name="dumptolanguage">ntriple=N-TRIPLE</Param>
+	
+	<!--OUTPUT : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="output"> The model described by this config file is the model that will be produced which will       %>
+<%     contain the data which is in the minuend but not in the subtrahend.                                            %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+<!--     <Param name="output">diff-output.model.xml</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="selective-diff"> Tells Diff to use the selectiveDiff method in execute. If any "update-types"	      %>
+<%  parameters (below) are set, this flag is implicitly set. This flag exists mostly for the case where one wishes    %>
+<%  to use selectiveDiff without specifying update types.                       				      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="selective-diff">T</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="update-types"> Each update-types entry specifies a type allowed to be updated in the process of      %>
+<%     a diff, meant primarily for creating subtraction models. Untested for addition models!		      	      %>
+<%														      %>
+<%     Specifying any type at all will cause Diff to use the selectiveDiff() method, leading to unspecified types     %>
+<%     being preserved.                                  							      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+	<!-- <Param name="update-types">http://xmlns.com/foaf/0.1/Person</Param> -->
+        <Param name="wordiness">INFO</Param> 
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/dspace-oaifetch.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/dspace-oaifetch.conf.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Config>
+
+<Param name="url">https://dspace.mit.edu/oai/request</Param>
+
+<!--
+<Param name="url">aei.pitt.edu/cgi/oai2</Param>
+<Param name="url">www4.fao.org:8080/oaicat/OAIHandler</Param>
+-->
+<Param name="start">2023-05-15T00:00:00Z</Param>
+<Param name="end">2023-05-17T00:00:00Z</Param>
+<Param name="metadataPrefix">oai_dc</Param>
+<!--<Param name="setSpec">example_set</Param>-->
+<Param name="output">raw-records.config.xml</Param>
+<Param name="wordiness">INFO</Param>
+</Config>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/harvested-data.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/harvested-data.model.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Config>
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Models ===== 																									%>
+<%	type - defines which type of jena model																				%>
+<%		Possible Values:																								%>
+<%			<Param name="type">tdb</Param> - defines a tdb jena model													%>
+<%			<Param name="type">sdb</Param> - defines an sdb jena model													%>
+<%			<Param name="type">rdb</Param> - defines an rdb jena model													%>
+<%			<Param name="type">file</Param> - defines an rdf file to use as a model										%>
+<%																														%>
+<%	===== Model Parameters ===== 																						%>
+<%	dbDir - the directory to store a tdb model in 																		%>
+<%			(only needed when type is tdb)	 																			%>
+<%		Example Values:																									%>
+<%			<Param name="dbDir">/absolute/path/to/dir</Param> - An absolute path to a directory on						%>
+<%				linux/unix/macosx operating systems																		%>
+<%			<Param name="dbDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on					%>
+<%				a windows operating system																				%>
+<%			<Param name="dbDir">relative/path/to/dir</Param> - A path to a directory that is relative					%>
+<%				to the folder the shell was in when this command was executed											%>
+<%	=== 																												%>
+<%																														%>
+<%	file - the path to the file that contains rdf data 																	%>
+<%			(only needed when type is file) 																			%>
+<%		Example Values:																									%>
+<%			<Param name="file">/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf					%>
+<%				file on linux/unix/macosx operating systems																%>
+<%			<Param name="file">C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf						%>
+<%				file on a windows operating system																		%>
+<%			<Param name="file">relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is					%>
+<%				relative to the folder the shell was in when this command was executed									%>
+<%	=== 																												%>
+<%																														%>
+<%	rdfLang - the format of the rdf in the file																			%>
+<%			(optional, only used when type is file) 																	%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="rdfLang">RDF/XML</Param> - rdf/xml format											%>
+<%			<Param name="rdfLang">N3</Param> - n3 format																%>
+<%			<Param name="rdfLang">TTL</Param> - turtle/ttl format														%>
+<%			<Param name="rdfLang">N-TRIPLE</Param> - n-triple format													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbLayout - the layout to use for an sdb model 																		%>
+<%			(optional, only used when type is sdb) 																		%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="dbLayout">layout2</Param> - layout2													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbType - the name of the database type (as specified by jena) 														%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbType">MySQL</Param> - mysql database															%>
+<%			<Param name="dbType">H2</Param> - h2 database																%>
+<%	=== 																												%>
+<%																														%>
+<%	dbClass - the JDBC driver class to use 																				%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - mysql database										%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - h2 database													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUrl - the JDBC connection url 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database								%>
+<%				see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - h2 database											%>
+<%				see http://www.h2database.com/html/features.html#database_url											%>
+<%	=== 																												%>
+<%																														%>
+<%	modelName - the named model to use																					%>
+<%			(optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )					%>
+<%		Examples: 																										%>
+<%			<Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>							%>
+<%			<Param name="modelName">mySimpleModelName</Param>															%>
+<%			<Param name="modelName">http://vivo.localinstitution.edu/models/my-uri-model</Param>						%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUser - the DB username to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	=== 																												%>
+<%																														%>
+<%	dbPass - the DB password to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%																														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample tdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/tdb-jena-rh</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample file model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">file</Param>
+	<Param name="file">data/file-jena-rh.rdf.n3</Param>
+	<Param name="rdfLang">N3</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample rdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">rdb</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample sdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">sdb</Param>
+	<Param name="dbLayout">layout2</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/harvested-data/</Param>
+</Config>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/match-authorship.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/match-authorship.conf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<!--
+	input-config - relative path to the configuration file for the Jena model containing the data to
+	               potentially rename.
+	-->
+	<Param name="input-config">harvested-data.model.xml</Param>
+	
+	<!--
+	score-config - relative path to the configuration file for the Jena model containing the data provided by
+	               Score to be analyzed for a match.
+	-->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--
+	rename - true if we want to perform an in-place rename on all matches.
+	-->
+	<Param name="rename">true</Param>
+	
+	<!--
+	threshold - a floating-point number which the Score value must meet or exceed in order for there to be
+	            considered a match.
+	-->
+	<Param name="threshold">0.7</Param>
+        <Param name="wordiness">INFO</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/match-main.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/match-main.conf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<!--
+	input-config - relative path to the configuration file for the Jena model containing the data to
+	               potentially rename.
+	-->
+	<Param name="input-config">harvested-data.model.xml</Param>
+	
+	<!--
+	score-config - relative path to the configuration file for the Jena model containing the data provided by
+	               Score to be analyzed for a match.
+	-->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--
+	rename - true if we want to perform an in-place rename on all matches.
+	-->
+	<Param name="rename">true</Param>
+	
+	<!--
+	threshold - a floating-point number which the Score value must meet or exceed in order for there to be
+	            considered a match.
+	-->
+	<Param name="threshold">0.7</Param>
+        <Param name="wordiness">INFO</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/match-pub.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/match-pub.conf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<!--
+	input-config - relative path to the configuration file for the Jena model containing the data to
+	               potentially rename.
+	-->
+	<Param name="input-config">harvested-data.model.xml</Param>
+	
+	<!--
+	score-config - relative path to the configuration file for the Jena model containing the data provided by
+	               Score to be analyzed for a match.
+	-->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--
+	rename - true if we want to perform an in-place rename on all matches.
+	-->
+	<Param name="rename">true</Param>
+	
+	<!--
+	threshold - a floating-point number which the Score value must meet or exceed in order for there to be
+	            considered a match.
+	-->
+	<Param name="threshold">0.7</Param>
+        <Param name="wordiness">INFO</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/oaifetch-dc.datamap.xsl
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/oaifetch-dc.datamap.xsl
@@ -1,0 +1,294 @@
+<xsl:stylesheet version="2.0"
+                xmlns:xsl = "http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs = "http://www.w3.org/2001/XMLSchema"
+                xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:rdfs = "http://www.w3.org/2000/01/rdf-schema#"
+                xmlns:vivo = "http://vivoweb.org/ontology/core#"
+                xmlns:score = "http://vivoweb.org/ontology/score#"
+                xmlns:foaf = "http://xmlns.com/foaf/0.1/"
+                xmlns:bibo = "http://purl.org/ontology/bibo/"
+                xmlns:obo = "http://purl.obolibrary.org/obo/"
+                xmlns:vitro = "http://vitro.mannlib.cornell.edu/ns/vitro/0.7#"
+                xmlns:vcard = "http://www.w3.org/2006/vcard/ns#"
+                xmlns:geo = "http://aims.fao.org/aos/geopolitical.owl#"
+                xmlns:mets = "http://www.loc.gov/METS/"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:node-oai = "http://vivo.example.com/harvest/fields/oai/"
+                xmlns:localVivo = "http://vivo.sample.edu/ontology/"
+                xmlns:oai_dc = "http://www.openarchives.org/OAI/2.0/oai_dc/"
+                xmlns:dc = "http://purl.org/dc/elements/1.1/"
+                xmlns:core = 'http://vivoweb.org/ontology/core#'
+                xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsdhttp://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd"
+                xmlns:stringhash="java:org.vivoweb.harvester.util.xslt.StringHash"
+                extension-element-prefixes = "stringhash"
+>
+    <xsl:output method="xml" indent="yes"/>
+
+    <!-- Authorship keys -->
+    <xsl:key name="authorships"
+             match="dc:creator"
+             use="concat('authorship_author/', translate(encode-for-uri(translate(normalize-space(.), ' ', '')), '%', ''), $documentId)" />
+
+    <!-- Global variables -->
+    <xsl:variable name="baseURI">http://vivo.example.com/harvest/</xsl:variable>
+    <xsl:variable name="documentId" select="translate(encode-for-uri(translate(/oai_dc:dc/dc:identifier[1], ' ', '')), '%', '')" />
+    <xsl:variable name="documentURI" select="concat($baseURI, 'oai/', translate(encode-for-uri(translate(/oai_dc:dc/dc:identifier[1], ' ', '')), '%', ''))" />
+
+
+    <xsl:template match="/oai_dc:dc">
+        <rdf:RDF>
+            <rdf:Description rdf:about="{$documentURI}">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Document" />
+                <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing" />
+                <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002" />
+                <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001" />
+                <rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031" />
+                <rdf:type rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030" />
+
+
+                <!-- Add vivo:relatedBy for all Authorships -->
+                <xsl:for-each select="dc:creator">
+                    <xsl:variable name="authorshipId" select="concat('authorship_author/', translate(encode-for-uri(translate(normalize-space(.), ' ', '')), '%', ''), $documentId)" />
+                    <vivo:relatedBy rdf:resource="{$baseURI}{$authorshipId}" />
+                </xsl:for-each>
+
+                <xsl:apply-templates select="*[not(self::dc:creator or self::dc:contributor)]" />
+            </rdf:Description>
+
+            <!-- Process authors and contributors -->
+            <xsl:apply-templates select="dc:creator" />
+            <xsl:apply-templates select="dc:contributor" />
+        </rdf:RDF>
+    </xsl:template>
+
+    <!-- Title -->
+    <xsl:template match="dc:title">
+        <rdfs:label><xsl:value-of select="normalize-space(.)"/></rdfs:label>
+    </xsl:template>
+
+    <!-- Subject -->
+    <xsl:template match="dc:subject">
+        <vivo:hasSubjectArea>
+            <rdf:Description rdf:about="{$baseURI}contributor/{translate(encode-for-uri(translate(normalize-space(.), ' ', '')), '%', '')}">
+                <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept" />
+                <rdfs:label><xsl:value-of select="normalize-space(.)"/></rdfs:label>
+            </rdf:Description>
+        </vivo:hasSubjectArea>
+    </xsl:template>
+
+    <!-- Description -->
+    <xsl:template match="dc:description">
+        <bibo:abstract><xsl:value-of select="normalize-space(.)"/></bibo:abstract>
+    </xsl:template>
+
+    <!-- Date -->
+    <xsl:template match="dc:date">
+        <vivo:dateTimeValue>
+            <rdf:Description rdf:about="{$baseURI}oai/{$documentId}">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue" />
+                <vivo:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="normalize-space(.)"/>
+                </vivo:dateTime>
+                <vivo:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearPrecision"/>
+            </rdf:Description>
+        </vivo:dateTimeValue>
+    </xsl:template>
+
+    <!-- Type -->
+    <xsl:template match="dc:type">
+        <xsl:choose>
+            <xsl:when test="ends-with(lower-case(.), 'article')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+            </xsl:when>
+
+            <xsl:when test="ends-with(lower-case(.), 'book')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+            </xsl:when>
+
+            <xsl:when test="ends-with(lower-case(.), 'chapter')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/chapter" />
+            </xsl:when>
+
+            <xsl:when test="ends-with(lower-case(.), 'dataset')">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Dataset" />
+            </xsl:when>
+
+            <xsl:when test="ends-with(lower-case(.), 'presentation')">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Presentation" />
+            </xsl:when>
+
+            <xsl:when test="contains(lower-case(.), 'recording')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/AudioDocument" />
+            </xsl:when>
+
+            <xsl:when test="contains(lower-case(.), 'software')">
+                <rdf:type rdf:resource="http://purl.obolibrary.org/obo/ERO_0000071" />
+            </xsl:when>
+
+            <xsl:when test="contains(lower-case(.), 'thesis')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Thesis" />
+            </xsl:when>
+
+            <xsl:when test="contains(lower-case(.), 'report')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Report" />
+            </xsl:when>
+
+            <xsl:when test="contains(lower-case(.), 'video')">
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/AudioVisualDocument" />
+            </xsl:when>
+
+            <xsl:when test="contains(lower-case(.), 'paper')">
+                <rdf:type rdf:resource="http://vivoweb.org/ontology/core#WorkingPaper" />
+            </xsl:when>
+
+            <xsl:otherwise>
+                <rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Identifier -->
+    <xsl:template match="dc:identifier">
+        <bibo:uri><xsl:value-of select="normalize-space(.)"/></bibo:uri>
+    </xsl:template>
+
+    <!-- Publisher -->
+    <xsl:template match="dc:publisher">
+        <vivo:publisher>
+            <rdf:Description rdf:about="{$baseURI}publisher/{translate(encode-for-uri(translate(normalize-space(.), ' ', '')), '%', '')}">
+                <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Organization" />
+                <rdfs:label><xsl:value-of select="normalize-space(.)"/></rdfs:label>
+
+                <vivo:publisherOf rdf:resource="{$documentURI}"/>
+            </rdf:Description>
+        </vivo:publisher>
+    </xsl:template>
+
+    <!-- Language -->
+    <xsl:template match="dc:language">
+        <vivo:language><xsl:value-of select="normalize-space(.)"/></vivo:language>
+    </xsl:template>
+
+    <!-- Relation -->
+    <xsl:template match="dc:relation">
+        <vivo:relatedLink>
+            <rdf:Description>
+                <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#URL" />
+                <vcard:url><xsl:value-of select="normalize-space(.)"/></vcard:url>
+            </rdf:Description>
+        </vivo:relatedLink>
+    </xsl:template>
+
+    <!-- Rights -->
+    <xsl:template match="dc:rights">
+        <bibo:rights><xsl:value-of select="normalize-space(.)"/></bibo:rights>
+    </xsl:template>
+
+    <!-- Format -->
+    <xsl:template match="dc:format">
+        <vivo:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">
+            <xsl:value-of select="normalize-space(.)"/>
+        </vivo:format>
+    </xsl:template>
+
+    <!-- Source -->
+    <xsl:template match="dc:source">
+        <bibo:source><xsl:value-of select="normalize-space(.)"/></bibo:source>
+    </xsl:template>
+
+    <!-- Coverage -->
+    <xsl:template match="dc:coverage">
+        <vivo:coverage><xsl:value-of select="normalize-space(.)"/></vivo:coverage>
+    </xsl:template>
+
+    <!-- Creator -->
+    <xsl:template match="dc:creator">
+        <!-- Output Authorship and Person separately -->
+        <xsl:variable name="authorId" select="concat('author/', translate(encode-for-uri(translate(normalize-space(.), ' ', '')), '%', ''))"/>
+        <xsl:variable name="authorURI" select="concat($baseURI, $authorId)"/>
+        <xsl:variable name="authorshipId" select="concat('authorship_', $authorId, $documentId)"/>
+        <xsl:variable name="authorName" select="normalize-space(.)"/>
+
+        <!-- Authorship -->
+        <rdf:Description rdf:about="{$baseURI}{$authorshipId}">
+            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+            <rdfs:label>Authorship for <xsl:value-of select="$authorName"/></rdfs:label>
+
+            <core:relates rdf:resource="{$documentURI}"/>
+            <core:relates rdf:resource="{$authorURI}" />
+
+            <core:authorRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">
+                <xsl:value-of select="position()" />
+            </core:authorRank>
+        </rdf:Description>
+
+        <!-- Person -->
+        <rdf:Description rdf:about="{$authorURI}">
+            <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person" />
+            <rdfs:label><xsl:value-of select="$authorName"/></rdfs:label>
+
+            <vivo:relatedBy rdf:resource="{$baseURI}{$authorshipId}" />
+            <core:relates rdf:resource="{$documentURI}"/>
+        </rdf:Description>
+
+        <xsl:variable name="vcardURI" select="concat($baseURI, 'vcard_', $authorshipId)"/>
+        <xsl:variable name="vcardNameURI" select="concat($baseURI, 'vcardName_', $authorshipId)"/>
+
+        <!-- vcard -->
+        <rdf:Description rdf:about="{$vcardURI}">
+            <obo:ARG_2000029 rdf:resource="{$authorURI}"/>
+            <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+            <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard for: <xsl:value-of select="$authorName" /></rdfs:label>
+            <vcard:hasName rdf:resource="{$vcardNameURI}"/>
+        </rdf:Description>
+
+        <!-- vcard name -->
+        <rdf:Description rdf:about="{$vcardNameURI}">
+            <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
+            <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard name for: <xsl:value-of select="$authorName" /></rdfs:label>
+            <vcard:givenName><xsl:value-of select = "$authorName" /></vcard:givenName>
+        </rdf:Description>
+    </xsl:template>
+
+    <!-- Contributor -->
+    <xsl:template match="dc:contributor">
+        <xsl:variable name="contributorName" select="normalize-space(.)"/>
+        <xsl:variable name="isPerson" select="contains($contributorName, ',')"/>
+
+        <xsl:choose>
+            <!-- If contributor is a person -->
+            <xsl:when test="$isPerson">
+                <xsl:variable name="contributorId" select="concat('author/', translate(encode-for-uri(translate($contributorName, ' ', '')), '%', ''))"/>
+                <xsl:variable name="contributorURI" select="concat($baseURI, $contributorId)"/>
+                <xsl:variable name="authorshipId" select="concat('authorship_', $contributorId, $documentId)"/>
+
+                <!-- Authorship -->
+                <rdf:Description rdf:about="{$baseURI}{$authorshipId}">
+                    <rdf:type rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+                    <core:relates rdf:resource="{$documentURI}" />
+                    <core:relates rdf:resource="{$contributorURI}" />
+                </rdf:Description>
+
+                <!-- Person -->
+                <rdf:Description rdf:about="{$contributorURI}">
+                    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person" />
+                    <rdfs:label><xsl:value-of select="$contributorName"/></rdfs:label>
+
+                    <vivo:relatedBy rdf:resource="{$baseURI}{$authorshipId}" />
+                    <core:relates rdf:resource="{$documentURI}"/>
+                </rdf:Description>
+
+                <rdf:Description rdf:about="{$documentURI}">
+                    <vivo:relatedBy rdf:resource="{$contributorURI}" />
+                </rdf:Description>
+            </xsl:when>
+
+            <!-- If contributor is a keyword or organization -->
+            <xsl:otherwise>
+<!--            Nothing for now-->
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/previous-harvest.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/previous-harvest.model.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Model>
+    <Param name="type">tdb</Param>
+    <Param name="dbDir">previous-harvest</Param>
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/raw-records.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/raw-records.config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<RecordHandler>
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/raw-records</Param>
+</RecordHandler>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/run-dspace-oaifetch.bat
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/run-dspace-oaifetch.bat
@@ -1,0 +1,117 @@
+@echo off
+REM ============================
+REM HARVESTER SCRIPT
+REM ============================
+
+REM Clean up previous data and logs
+IF exist data (
+  echo Removing 'data' directory...
+  rmdir /s /q data
+)
+
+IF exist logs (
+  echo Removing 'logs' directory...
+  rmdir /s /q logs
+)
+
+REM Load method selection (default: sparql)
+set LOAD_METHOD=sparql
+
+if not "%~1"=="" (
+    if /I "%~1"=="tdb" (
+        set LOAD_METHOD=tdb
+    ) else if /I "%~1"=="sparql" (
+        set LOAD_METHOD=sparql
+    ) else (
+        echo Invalid argument: %~1
+        echo Usage: %~nx0 [tdb|sparql]
+        exit /b 1
+    )
+)
+
+REM Set installation directory
+REM Replace this with the actual installation path
+set "HARVESTER_INSTALL_DIR=%cd%\..\..\..\..\..\..\VIVO-Harvester"
+
+REM Validate HARVESTER_INSTALL_DIR
+IF NOT EXIST "%HARVESTER_INSTALL_DIR%" (
+    echo ERROR: HARVESTER_INSTALL_DIR does not exist: %HARVESTER_INSTALL_DIR%
+    exit /b 1
+)
+
+REM Set today's date
+FOR /F "tokens=2-4 delims=/ " %%A IN ('date /t') DO set Today=%%A%%B%%C
+
+REM Classpath setup
+set CLASSPATH=%HARVESTER_INSTALL_DIR%\build\harvester.jar;%HARVESTER_INSTALL_DIR%\build\dependency\*
+
+REM Java options
+set HARVESTER_JAVA_OPTS=-Xms1024M -Xmx2048M
+
+REM ============================
+REM Fetch Stage
+REM ============================
+echo Fetching from DSpace...
+IF NOT EXIST dspace-oaifetch.conf.xml (
+    echo ERROR: Missing configuration file: dspace-oaifetch.conf.xml
+    exit /b 1
+)
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.fetch.OAIFetch -X dspace-oaifetch.conf.xml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM ============================
+REM Translate Stage
+REM ============================
+echo Translating data to valid RDF...
+IF NOT EXIST xsltranslator.config.xml (
+    echo ERROR: Missing configuration file: xsltranslator.config.xml
+    exit /b 1
+)
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.translate.XSLTranslator -X xsltranslator.config.xml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM ============================
+REM Transfer Stage
+REM ============================
+echo Transferring RDF into temporary triple store...
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.transfer.Transfer -w INFO -s translated-records.config.xml -o harvested-data.model.xml -d data/harvested-data/imported-records.rdf.xml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM ============================
+REM Diff Stage
+REM ============================
+echo Finding Subtractions...
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.diff.Diff -X diff-subtractions.config.xml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo Finding Additions...
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.diff.Diff -X diff-additions.config.xml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM ============================
+REM Apply Changes
+REM ============================
+echo Applying Subtractions to Previous model...
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.transfer.Transfer -w INFO -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -m
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo Applying Additions to Previous model...
+java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.transfer.Transfer -w INFO -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+REM Apply to VIVO model
+if "%LOAD_METHOD%"=="tdb" (
+    echo Applying Subtractions to VIVO model...
+    java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.transfer.Transfer -w INFO -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -m
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    echo Applying Additions to VIVO model...
+    java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.transfer.Transfer -w INFO -o vivo.model.xml -r data/vivo-additions.rdf.xml
+    if %errorlevel% neq 0 exit /b %errorlevel%
+) else (
+    echo Applying changes using SPARQL update...
+    java %HARVESTER_JAVA_OPTS% -cp "%CLASSPATH%" org.vivoweb.harvester.services.SparqlUpdate -X sparqlupdate.conf.xml
+)
+
+echo Harvest completed successfully.
+exit /b 0

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/run-dspace-oaifetch.sh
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/run-dspace-oaifetch.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+if [[ "$1" != "" && "$1" != "tdb" && "$1" != "sparql" ]]; then
+  echo "Invalid argument: $1"
+  echo "Usage: $0 [tdb|sparql]"
+  exit 1
+fi
+
+#Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+#All rights reserved.
+#This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+
+# set to the directory where the harvester was installed or unpacked
+# HARVESTER_INSTALL_DIR is set to the location of the installed harvester
+#	If the deb file was used to install the harvester then the
+#	directory should be set to /usr/share/vivo/harvester which is the
+#	current location associated with the deb installation.
+#	Since it is also possible the harvester was installed by
+#	uncompressing the tar.gz the setting is available to be changed
+#	and should agree with the installation location
+#export HARVESTER_INSTALL_DIR=<HARVESTER_INSTALL_DIR>
+HARVESTER_INSTALL_DIR=$(pwd)/../../../../../../VIVO-Harvester
+export HARVEST_NAME=DSpace-OAI-fetch
+export DATE=`date +%Y-%m-%d'T'%T`
+
+# Add harvester binaries to path for execution
+# The tools within this script refer to binaries supplied within the harvester
+#	Since they can be located in another directory their path should be
+#	included within the classpath and the path environment variables.
+export PATH=$PATH:$HARVESTER_INSTALL_DIR/bin
+export CLASSPATH=$CLASSPATH:$HARVESTER_INSTALL_DIR/bin/harvester.jar:$HARVESTER_INSTALL_DIR/bin/dependency/*
+export CLASSPATH=$CLASSPATH:$HARVESTER_INSTALL_DIR/build/harvester.jar:$HARVESTER_INSTALL_DIR/build/dependency/*
+
+# Exit on first error
+# The -e flag prevents the script from continuing even though a tool fails.
+#	Continuing after a tool failure is undesirable since the harvested
+#	data could be rendered corrupted and incompatible.
+set -e
+
+# Supply the location of the detailed log file which is generated during the script.
+#	If there is an issue with a harvest, this file proves invaluable in finding
+#	a solution to the problem. It has become common practice in addressing a problem
+#	to request this file. The passwords and usernames are filtered out of this file
+#	to prevent these logs from containing sensitive information.
+echo "Full Logging in $HARVEST_NAME.$DATE.log"
+if [ ! -d logs ]; then
+  mkdir logs
+fi
+cd logs
+touch $HARVEST_NAME.$DATE.log
+ln -sf $HARVEST_NAME.$DATE.log $HARVEST_NAME.latest.log
+cd ..
+
+#clear old data
+# For a fresh harvest, the removal of the previous information maintains data integrity.
+#	If you are continuing a partial run or wish to use the old and already retrieved
+#	data, you will want to comment out this line since it could prevent you from having
+# 	the required harvest data.  
+rm -rf data
+
+# Execute Fetch
+# This stage of the script is where the information is gathered together into one local
+#	place to facilitate the further steps of the harvest. The data is stored locally
+#	in a format based off of the source. The format is a form of RDF but not in the VIVO ontology
+java $HARVESTER_JAVA_OPTS org.vivoweb.harvester.fetch.OAIFetch -X dspace-oaifetch.conf.xml
+
+# Execute Translate
+# This is the part of the script where the input data is transformed into valid RDF
+#   Translate will apply an xslt file to the fetched data which will result in the data
+#   becoming valid RDF in the VIVO ontology
+harvester-xsltranslator -X xsltranslator.config.xml
+
+# Execute Transfer to import from record handler into local temp model
+# From this stage on the script places the data into a Jena model. A model is a
+#	data storage structure similar to a database, but in RDF.
+# The harvester tool Transfer is used to move/add/remove/dump data in models.
+# For this call on the transfer tool:
+# -s refers to the source translated records file, which was just produced by the translator step
+# -o refers to the destination model for harvested data
+# -d means that this call will also produce a text dump file in the specified location
+harvester-transfer -w INFO -s translated-records.config.xml -o harvested-data.model.xml -d data/harvested-data/imported-records.rdf.xml
+
+#Score on publications
+# Compare names of publications in VIVO with names of publications from MODS and assign a
+#	score value indicating how likely they are the same publication.
+#harvester-score -X score-pub.conf.xml
+
+#Match publications
+# Use the score values from the previous score to rename publications which we deem are the
+#	same, so that they match the URI of the publication in VIVO.
+#harvester-match -X match-pub.conf.xml
+
+#Score on authors, organizations, geographic locations, journals, hyperlinks, and
+#	date-time intervals
+# Same as above, but for authors, organizations, geographic locations, journals, hyperlinks,
+#	and date-time intervals.
+#harvester-score -X score-author.conf.xml
+#harvester-score -X score-publisher.conf.xml
+
+#harvester-score -X score-interval.conf.xml
+#harvester-score -X score-datetime.conf.xml
+
+#Match
+# Rename matches scored above.
+#harvester-match -X match-main.conf.xml
+
+#Score on authorships
+# Same as above, but for authorships.
+#harvester-score -X score-authorship.conf.xml
+
+#Match
+# Rename matching authorships.
+#harvester-match -X match-authorship.conf.xml
+
+#Truncate Score Data model
+#harvester-jenaconnect -X truncate.config.xml
+
+
+# Execute ChangeNamespace to get unmatched publications into current namespace
+# This is where the new people from the harvest are given uris within the namespace of Vivo
+# 	If there is an issue with uris being in another namespace after import, make sure this step
+#   was completed for those uris.
+
+#echo "changenamespace"
+#harvester-changenamespace -X changenamespace-all.config.xml
+
+
+# Dump harvested data model for testing
+# harvester-jenaconnect -X harvested-dump.config.xml
+
+# Perform an update
+# The harvester maintains copies of previous harvests in order to perform the same harvest twice
+#   but only add the new statements, while removing the old statements that are no longer
+#   contained in the input data. This is done in several steps of finding the old statements,
+#   then the new statements, and then applying them to the Vivo main model.
+
+# Find Subtractions
+# When making the previous harvest model agree with the current harvest, the statements that exist in
+#	the previous harvest but not in the current harvest need to be identified for removal.
+harvester-diff -X diff-subtractions.config.xml
+
+# Find Additions
+# When making the previous harvest model agree with the current harvest, the statements that exist in
+#	the current harvest but not in the previous harvest need to be identified for addition.
+harvester-diff -X diff-additions.config.xml
+
+# Apply Subtractions to Previous model
+harvester-transfer -w info -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -m
+# Apply Additions to Previous model
+harvester-transfer -w info -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml
+
+# Now that the changes have been applied to the previous harvest and the harvested data in vivo
+#	agree with the previous harvest, the changes are now applied to the vivo model.
+if [[ "$1" == "tdb" ]]; then
+  # Apply Subtractions to VIVO model
+  harvester-transfer -w info -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -m
+  # Apply Additions to VIVO model
+  harvester-transfer -w info -o vivo.model.xml -r data/vivo-additions.rdf.xml
+fi
+
+if [[ "$1" == "" || "$1" == "sparql" ]]; then
+  java $HARVESTER_JAVA_OPTS org.vivoweb.harvester.services.SparqlUpdate -X sparqlupdate.conf.xml
+fi
+
+#Output some counts
+PUBS=`cat data/vivo-additions.rdf.xml | grep oai | wc -l`
+AUTHORS=`cat data/vivo-additions.rdf.xml | grep 'http://xmlns.com/foaf/0.1/Person' | wc -l`
+AUTHORSHIPS=`cat data/vivo-additions.rdf.xml | grep Authorship | wc -l`
+echo "Imported $PUBS publications, $AUTHORS authors, and $AUTHORSHIPS authorships"
+
+echo 'Harvest completed successfully'

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-author.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-author.conf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<Param name="inputJena-config">harvested-data.model.xml</Param>
+	<Param name="vivoJena-config">vivo.model.xml</Param>
+	<Param name="score-config">score-data.model.xml</Param>
+	<Param name="algorithms">fName=org.vivoweb.harvester.score.algorithm.NormalizedLevenshteinDifference</Param>
+	<Param name="inputJena-predicates">fName=http://www.w3.org/2000/01/rdf-schema#label</Param>
+	<Param name="weights">fName=0.3</Param>
+	<Param name="vivoJena-predicates">fName=http://www.w3.org/2000/01/rdf-schema#label</Param>
+	<Param name="namespace">http://vivo.example.com/harvest/author/</Param>
+        <Param name="wordiness">INFO</Param>
+</Task>
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-authorship.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-authorship.conf.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<Param name="inputJena-config">harvested-data.model.xml</Param>
+	<Param name="vivoJena-config">vivo.model.xml</Param>
+	<Param name="score-config">score-data.model.xml</Param>
+
+	<Param name="algorithms">authpub=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	<Param name="inputJena-predicates">authpub=http://vivoweb.org/ontology/core#linkedInformationResource</Param>
+	<Param name="weights">authpub=0.5</Param>
+	<Param name="vivoJena-predicates">authpub=http://vivoweb.org/ontology/core#linkedInformationResource</Param>
+
+	<Param name="algorithms">authauth=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	<Param name="inputJena-predicates">authauth=http://vivoweb.org/ontology/core#linkedAuthor</Param>
+	<Param name="weights">authauth=0.5</Param>
+	<Param name="vivoJena-predicates">authauth=http://vivoweb.org/ontology/core#linkedAuthor</Param>
+
+	<Param name="namespace">http://vivo.example.com/harvest/authorship_author/</Param>
+        <Param name="wordiness">INFO</Param>
+</Task>
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-data.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-data.model.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Config>
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Models ===== 																									%>
+<%	type - defines which type of jena model																				%>
+<%		Possible Values:																								%>
+<%			<Param name="type">tdb</Param> - defines a tdb jena model													%>
+<%			<Param name="type">sdb</Param> - defines an sdb jena model													%>
+<%			<Param name="type">rdb</Param> - defines an rdb jena model													%>
+<%			<Param name="type">file</Param> - defines an rdf file to use as a model										%>
+<%																														%>
+<%	===== Model Parameters ===== 																						%>
+<%	dbDir - the directory to store a tdb model in 																		%>
+<%			(only needed when type is tdb)	 																			%>
+<%		Example Values:																									%>
+<%			<Param name="dbDir">/absolute/path/to/dir</Param> - An absolute path to a directory on						%>
+<%				linux/unix/macosx operating systems																		%>
+<%			<Param name="dbDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on					%>
+<%				a windows operating system																				%>
+<%			<Param name="dbDir">relative/path/to/dir</Param> - A path to a directory that is relative					%>
+<%				to the folder the shell was in when this command was executed											%>
+<%	=== 																												%>
+<%																														%>
+<%	file - the path to the file that contains rdf data 																	%>
+<%			(only needed when type is file) 																			%>
+<%		Example Values:																									%>
+<%			<Param name="file">/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf					%>
+<%				file on linux/unix/macosx operating systems																%>
+<%			<Param name="file">C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf						%>
+<%				file on a windows operating system																		%>
+<%			<Param name="file">relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is					%>
+<%				relative to the folder the shell was in when this command was executed									%>
+<%	=== 																												%>
+<%																														%>
+<%	rdfLang - the format of the rdf in the file																			%>
+<%			(optional, only used when type is file) 																	%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="rdfLang">RDF/XML</Param> - rdf/xml format											%>
+<%			<Param name="rdfLang">N3</Param> - n3 format																%>
+<%			<Param name="rdfLang">TTL</Param> - turtle/ttl format														%>
+<%			<Param name="rdfLang">N-TRIPLE</Param> - n-triple format													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbLayout - the layout to use for an sdb model 																		%>
+<%			(optional, only used when type is sdb) 																		%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="dbLayout">layout2</Param> - layout2													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbType - the name of the database type (as specified by jena) 														%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbType">MySQL</Param> - mysql database															%>
+<%			<Param name="dbType">H2</Param> - h2 database																%>
+<%	=== 																												%>
+<%																														%>
+<%	dbClass - the JDBC driver class to use 																				%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - mysql database										%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - h2 database													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUrl - the JDBC connection url 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database								%>
+<%				see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - h2 database											%>
+<%				see http://www.h2database.com/html/features.html#database_url											%>
+<%	=== 																												%>
+<%																														%>
+<%	modelName - the named model to use																					%>
+<%			(optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )					%>
+<%		Examples: 																										%>
+<%			<Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>							%>
+<%			<Param name="modelName">mySimpleModelName</Param>															%>
+<%			<Param name="modelName">http://vivo.localinstitution.edu/models/my-uri-model</Param>						%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUser - the DB username to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	=== 																												%>
+<%																														%>
+<%	dbPass - the DB password to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%																														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample tdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/tdb-jena-rh</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample file model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">file</Param>
+	<Param name="file">data/file-jena-rh.rdf.n3</Param>
+	<Param name="rdfLang">N3</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample rdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">rdb</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample sdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">sdb</Param>
+	<Param name="dbLayout">layout2</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/score-data/</Param>
+</Config>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-pub.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-pub.conf.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+	<!--
+	inputJena-config - relative path to the configuration file of the Jena model containing the data to be compared with
+	                   data in VIVO.
+	-->
+	<Param name="inputJena-config">harvested-data.model.xml</Param>
+
+	<!--
+	vivoJena-config - relative path to the configuration file of the Jena model containing the VIVO data.
+	-->
+	<Param name="vivoJena-config">vivo.model.xml</Param>
+
+	<!--
+	score-config - relative path to the configuration file of the Jena model in which Score will place its output.
+	-->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--
+	algorithms - the Java class of the scoring algorithm to use for this comparison.  Must be preceded by "<identifier>=", where
+	             "<identifier>" is a string that is unique for each comparison being made, and is used to link the algorithms,
+	             inputJena-predicates, weights, and vivoJena-predicates values which all belong to the same comparison.
+	-->
+	<Param name="algorithms">title=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	
+	<!--
+	inputJena-predicates - the predicate to be used for the input data side of this comparison.  A record with this predicate from
+	             the input data will be compared to records in VIVO with the predicate specified in the vivoJena-predicates value
+	             for this comparison.  Must be preceded by "<identifier>=", where "<identifier>" is a string that is unique for
+	             each comparison being made, and is used to link the algorithms, inputJena-predicates, weights, and vivoJena-predicates
+	             values which all belong to the same comparison.
+	-->
+	<Param name="inputJena-predicates">title=http://www.w3.org/2000/01/rdf-schema#label</Param>
+	
+	<!--
+	weights - the weight assigned to this comparison.  The algorithm will return a floating point value, and this will then be multiplied
+	          by the weight to get the score value for this comparison.  Must be preceded by "<identifier>=", where "<identifier>" is a
+	          string that is unique for each comparison being made, and is used to link the algorithms, inputJena-predicates, weights,
+	          and vivoJena-predicates values which all belong to the same comparison.
+	-->
+	<Param name="weights">title=1.0</Param>
+	
+	<!--
+	vivoJena-predicates - the predicate to be used for the VIVO data side of this comparison.  A record with this predicate from
+	             VIVO will be compared to records in the input data with the predicate specified in the inputJena-predicates value
+	             for this comparison.  Must be preceded by "<identifier>=", where "<identifier>" is a string that is unique for
+	             each comparison being made, and is used to link the algorithms, inputJena-predicates, weights, and vivoJena-predicates
+	             values which all belong to the same comparison.
+	-->
+	<Param name="vivoJena-predicates">title=http://www.w3.org/2000/01/rdf-schema#label</Param>
+
+	<!--
+	namespace - the namespace of records to score within the input data.  Other records will be ignored. 
+	-->
+	<Param name="namespace">http://vivo.example.com/harvest/oai/</Param>
+        <Param name="wordiness">INFO</Param>
+</Task>
+
+
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-publisher.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-publisher.conf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <Param name="wordiness">DEBUG</Param>
+	<!--INPUT -->
+	<Param name="inputJena-config">harvested-data.model.xml</Param>
+	
+	<!--VIVO INPUT -->
+	<Param name="vivoJena-config">vivo.model.xml</Param>
+	
+	<!--SCORING DATA OUTPUT -->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--OPTIONS -->
+	  <!--  <Param name="tempJenaDir">data/temp-score-model</Param> -->
+	<Param name="namespace">http://vivo.example.com/harvest/publisher/</Param>
+			
+	<!--COMPARISIONS -->
+	
+	<!-- rdfs Label -->
+	<Param name="algorithms">vcard=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	<Param name="weights">vcard=1.0</Param>
+	<Param name="inputJena-predicates">vcard=http://www.w3.org/2000/01/rdf-schema#label</Param>
+	<Param name="vivoJena-predicates">vcard=http://www.w3.org/2000/01/rdf-schema#label</Param>
+
+</Task>
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-vcard-name.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-vcard-name.conf.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <Param name="wordiness">INFO</Param>
+	<!--INPUT -->
+	<Param name="inputJena-config">harvested-data.model.xml</Param>
+	
+	<!--VIVO INPUT -->
+	<Param name="vivoJena-config">vivo.model.xml</Param>
+	
+	<!--SCORING DATA OUTPUT -->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--OPTIONS -->
+      <!--  <Param name="tempJenaDir">data/temp-score-model</Param> -->
+	<Param name="namespace">http://vivo.example.com/harvest/vcardName_</Param>
+			
+	<!--COMPARISIONS -->
+	
+        <!-- given name -->
+	<Param name="algorithms">givenName=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	<Param name="weights">givenName=0.5</Param>
+	<Param name="inputJena-predicates">givenName=http://www.w3.org/2006/vcard/ns#givenName</Param>
+	<Param name="vivoJena-predicates">givenName=http://www.w3.org/2006/vcard/ns#givenName</Param>
+
+        <!-- family name -->
+	<Param name="algorithms">familyName=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	<Param name="weights">familyName=0.5</Param>
+	<Param name="inputJena-predicates">familyName=http://www.w3.org/2006/vcard/ns#familyName</Param>
+	<Param name="vivoJena-predicates">familyName=http://www.w3.org/2006/vcard/ns#familyName</Param>
+
+</Task>
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-vcard.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/score-vcard.conf.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <Param name="wordiness">DEBUG</Param>
+	<!--INPUT -->
+	<Param name="inputJena-config">harvested-data.model.xml</Param>
+	
+	<!--VIVO INPUT -->
+	<Param name="vivoJena-config">vivo.model.xml</Param>
+	
+	<!--SCORING DATA OUTPUT -->
+	<Param name="score-config">score-data.model.xml</Param>
+	
+	<!--OPTIONS -->
+	  <!--  <Param name="tempJenaDir">data/temp-score-model</Param> -->
+	<Param name="namespace">http://vivo.example.com/harvest/vcard_</Param>
+			
+	<!--COMPARISIONS -->
+	
+	<!-- rdfs Label -->
+	<Param name="algorithms">vcard=org.vivoweb.harvester.score.algorithm.EqualityTest</Param>
+	<Param name="weights">vcard=1.0</Param>
+	<Param name="inputJena-predicates">vcard=http://www.w3.org/2000/01/rdf-schema#label</Param>
+	<Param name="vivoJena-predicates">vcard=http://www.w3.org/2000/01/rdf-schema#label</Param>
+
+</Task>
+

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/sparqlupdate.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/sparqlupdate.conf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <Param name="wordiness">INFO</Param>
+    <!-- input -->
+    <Param name="rdf">data/vivo-additions.rdf.xml</Param>
+    <Param name="type">add</Param>
+    <!-- output -->
+
+    <Param name="url">http://localhost:8080/vivo/api/sparqlUpdate</Param>
+    <Param name="model">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>
+    <Param name="username">vivo_root@mydomain.edu</Param>
+    <Param name="password">admin123</Param>
+
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/translated-records.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/translated-records.config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<RecordHandler>
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/translated-records</Param>
+</RecordHandler>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/truncate.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/truncate.config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+
+<Config>
+    <Param name="jena">score-data.model.xml</Param>
+    <Param name="truncate">true</Param>
+    <Param name="wordiness">INFO</Param> 
+</Config>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/usage.txt
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/usage.txt
@@ -1,0 +1,23 @@
+This example will demonstrate fetching DSpace oai-phm provider which exposes content
+using DublinCore metadata format and loading it into a VIVO instance.
+
+You will need to:
+
+- Modify the dspace-oaifetch.conf.xml configuration file to specify harvest endpoint, time period, set, etc.
+- Examine the run-oaifetch.sh (or .bat) script and type the location of the VIVO Harvester installation directory.
+- You can uncomment the score and match functions if you want deduplication to be performed (it is turned off by default)
+- Modify the vivo.model.xml file to provide parameters for accessing your VIVO web application and tdbContentModels directory.
+- Shut down your VIVO instance (if you are performing load using the TDB, in order to free the TDB lock)
+- Run `run-dspace-oaifetch.sh [tdb/sparql]` (use .bat script if you are on WindowsOS. It is recommended that you perform the first harvest, especially for large datasets, using TDB, as SPARQL API may have trouble loading very large files. All subsequent re-harvests can be performed with SPARQL API without the need for restarting your VIVO instance)
+- If you imported using TDB, you have to recompute inferences using "Site Admin"->"Recompute inferences" in order to be able to properly browse imported data
+- Restart your VIVO instance (in case you loaded data using the TDB) and reindex the search indexes
+
+Note: When performing TDB import, if it's your first time running VIVO, it is mandatory that you first start up VIVO and wait for
+the default entities (ABAC, locations, initial concepts...) to initialize. Only after first initialization is it safe to perform TDB import.
+Failure to do this may result in losing all imported data when the application is restarted.
+
+Note: If you are running an older VIVO version, you should navigate to pom.xml and update jena.version to that of your VIVO instance. That way, you will
+avoid any compatibility issues when performing TDB import. Failure to do this may result in a simple "Error: null" message when trying to transfer your local TDB content models
+to the actual tdbContentModels directory.
+
+Note: It is recommended that when you are performing your initial harvest, you use TDB import. Every other time SPARQL API import should be your go-to method.

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/vivo.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/vivo.model.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  ===== Models =====                                                                                                  %>
+<%  type - defines which type of jena model                                                                             %>
+<%      Possible Values:                                                                                                %>
+<%          <Param name="scoreOverride">type=tdb</Param> - defines a tdb jena model                                     %>
+<%          <Param name="scoreOverride">type=sdb</Param> - defines an sdb jena model                                    %>
+<%          <Param name="scoreOverride">type=rdb</Param> - defines an rdb jena model                                    %>
+<%          <Param name="scoreOverride">type=file</Param> - defines an rdf file to use as a model                       %>
+<%                                                                                                                      %>
+<%  ===== Model Parameters =====                                                                                        %>
+<%  dbDir - the directory to store a tdb model in                                                                       %>
+<%          (only needed when type is tdb)                                                                              %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">dbDir=/absolute/path/to/dir</Param> - An absolute path to a directory on        %>
+<%              linux/unix/macosx operating systems                                                                     %>
+<%          <Param name="scoreOverride">dbDir=C:/absolute/path/to/dir</Param> - An absolute path to a directory on      %>
+<%              a windows operating system                                                                              %>
+<%          <Param name="scoreOverride">dbDir=relative/path/to/dir</Param> - A path to a directory that is relative     %>
+<%              to the folder the shell was in when this command was executed                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  file - the path to the file that contains rdf data                                                                  %>
+<%          (only needed when type is file)                                                                             %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">file=/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf    %>
+<%              file on linux/unix/macosx operating systems                                                             %>
+<%          <Param name="scoreOverride">file=C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf       %>
+<%              file on a windows operating system                                                                      %>
+<%          <Param name="scoreOverride">file=relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is      %>
+<%              relative to the folder the shell was in when this command was executed                                  %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  rdfLang - the format of the rdf in the file                                                                         %>
+<%          (optional, only used when type is file)                                                                     %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">rdfLang=RDF/XML</Param> - rdf/xml format                              %>
+<%          <Param name="scoreOverride">rdfLang=N3</Param> - n3 format                                                  %>
+<%          <Param name="scoreOverride">rdfLang=TTL</Param> - turtle/ttl format                                         %>
+<%          <Param name="scoreOverride">rdfLang=N-TRIPLE</Param> - n-triple format                                      %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbLayout - the layout to use for an sdb model                                                                       %>
+<%          (optional, only used when type is sdb)                                                                      %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">dbLayout=layout2</Param> - layout2                                    %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbType - the name of the database type (as specified by jena)                                                       %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbType=MySQL</Param> - mysql database                                           %>
+<%          <Param name="scoreOverride">dbType=H2</Param> - h2 database                                                 %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbClass - the JDBC driver class to use                                                                              %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbClass=com.mysql.jdbc.Driver</Param> - mysql database                          %>
+<%          <Param name="scoreOverride">dbClass=org.h2.Driver</Param> - h2 database                                     %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUrl - the JDBC connection url                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database               %>
+<%              see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html          %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:h2:path/to/h2/store</Param> - h2 database                            %>
+<%              see http://www.h2database.com/html/features.html#database_url                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  modelName - the named model to use                                                                                  %>
+<%          (optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )                   %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">modelName=http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>           %>
+<%          <Param name="scoreOverride">modelName=mySimpleModelName</Param>                                             %>
+<%          <Param name="scoreOverride">modelName=http://vivo.localinstitution.edu/models/my-uri-model</Param>          %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUser - the DB username to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbUser=sa</Param> - used for h2 database (the default h2 system admin login     %>
+<%          <Param name="scoreOverride">dbUser=myUser</Param>                                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbPass - the DB password to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbPass=</Param> - used for h2 database (the default h2 system admin login       %>
+<%          <Param name="scoreOverride">dbPass=myPass</Param>                                                           %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Model>
+    <Model>
+        <Param name="type">tdb</Param>
+        <Param name="dbDir">/home/ivanmrsulja/Desktop/posao/vivo/vivo_home/tdbContentModels</Param>
+        <Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>
+    </Model>
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/xsltranslator.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-oaifetch-dspace/xsltranslator.config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+   <Param name="wordiness">INFO</Param>
+   <!--INPUT -->
+   <Param name="input">raw-records.config.xml</Param>
+	
+   <!--OUTPUT -->
+   <Param name="output">translated-records.config.xml</Param>
+
+   <!--DATAMAP -->
+   <Param name="xslFile">oaifetch-dc.datamap.xsl</Param>
+
+   <Param name="force">true</Param>
+
+</Task>


### PR DESCRIPTION
Added an example of fetching publication metadata from DSpace based on the oaifetch.

Steps to run:

- Examine the run-oaifetch.sh (or .bat) script and type the location of the VIVO Harvester installation directory.
- You can uncomment the score and match functions if you want deduplication to be performed (it is turned off by default)
- Modify the vivo.model.xml file to provide parameters for accessing your VIVO web application.
- Modify the `dspace-oaifetch.conf.xml` to point to your desired instance's endpoint, as well as other OAI properties (keep in mind that only DublinCore metadata format is supported at this moment)
- Shut down your VIVO instance (in order to free the TDB lock)
- Run `run-dspace-oaifetch.sh` (or `.bat`, if you are on Windows)
- Restart your VIVO instance and reindex the search indexes

Closes [#4021](https://github.com/vivo-project/VIVO/issues/4021)