### PR TITLE
Pubmed Harvest

### DIFF
--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/.gitignore
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/.gitignore
@@ -1,0 +1,3 @@
+/data
+/previous-harvest
+/logs

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/README
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/README
@@ -1,0 +1,26 @@
+
+You need to modify certains files to ingest data using this example.
+
+Here are the files that need to be modified:
+
+1. vivo.model.xml
+
+check that the database information is configured correctly for your system.  By default, it will
+connect to a database called vitrodb_test on localhost
+
+2. run-pubmed.sh
+
+set to the directory where the harvester was installed
+HARVESTER_INSTALL_DIR
+(Note: there may be other shell scripts which have a set HARVESTER_INSTALL_DIR which
+will need to modified)
+
+3. pubmedfetch.config.xml
+
+change the search string (termSerch), email address, numRecords, and batchSize to suit your preferences
+
+5. all the changenamespace-*.config.xml files
+
+change the "newNamespace" value to the namespace of your VIVO instance
+
+CAVEAT: After the ingest is complete you will need to log onto the vivo instance ro rebuild the index and recompute inferences.

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/diff-additions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/diff-additions.config.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%    The diff tool is used to compare jena models and produce a result model which is the first model (minuend)      %>
+<%       with any matching statements in the second model (subtrahend) removed from it.                               %>
+<%    =====                                                                                                           %>
+<%    This tool produces the graph-math difference of the triples between two models. It produces a model with the    %>
+<%       triples which are in the minuend and not in the subtrahend.                                                  %>
+<%    Expressed mathematically as minuend - subtrahend = difference                                                   %>
+<%    Neither the minend nor the subtrahend are altered.                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Task>
+	<!--INPUT -->
+	    <!--MINUEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="minuend"> The model described by this config file is the model which has the data which will be in   %>
+<%     output model.                                                                                                  %>
+<%                                                                                                                    %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="minuend">harvested-data.model.xml</Param>
+
+	<!--VIVO -->
+		<!--SUBTRAHEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="subtrahend"> The model described by this config file contains the triples which are not goning to    %>
+<%     be within the output model. If the triples match any within the minuend model then the output will be smaller  %>
+<%     than the minuend.                                                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="subtrahend">previous-harvest.model.xml</Param>
+	
+	<!-- OPTIONS -->
+	    <!--DUMPFILE -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="dumptofile"> This denotes the place for a text dump file to be produced. The default format of the   %>
+<%  dumpfile is RDF/XML and is able to be added or removed from another model through the use of the transfer tool.   %>
+<%  <Param name="dumptolanguage"> This denotes the language the rdf is in. Predefined values for lang are "RDF/XML",  %>
+<%  "N-TRIPLE", "TURTLE" (or "TTL") and "N3". * null represents the default language, "RDF/XML". "RDF/XML-ABBREV" is  %>
+<%  a synonym for "RDF/XML".					  																	  %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="dumptofile">xmlrdf=data/vivo-additions.rdf.xml</Param>
+	<Param name="dumptolanguage">xmlrdf=RDF/XML</Param>
+	<Param name="dumptofile">ntriple=data/vivo-ntriple-additions.xml</Param>
+	<Param name="dumptolanguage">ntriple=N-TRIPLE</Param>
+
+	<!--OUTPUT : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="output"> The model described by this config file is the model that will be produced which will       %>
+<%     contain the data which is in the minuend but not in the subtrahend.                                            %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="output">diff-output.model.xml</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="selective-diff"> Tells Diff to use the selectiveDiff method in execute. If any "update-types"	      %>
+<%  parameters (below) are set, this flag is implicitly set. This flag exists mostly for the case where one wishes    %>
+<%  to use selectiveDiff without specifying update types.                       				      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="selective-diff">T</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="update-types"> Each update-types entry specifies a type allowed to be updated in the process of      %>
+<%     a diff, meant primarily for creating subtraction models. Untested for addition models!		      	      %>
+<%														      %>
+<%     Specifying any type at all will cause Diff to use the selectiveDiff() method, leading to unspecified types     %>
+<%     being preserved.                                  							      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+	<!-- <Param name="update-types">http://xmlns.com/foaf/0.1/Person</Param> -->
+        <Param name="wordiness">INFO</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/diff-subtractions.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/diff-subtractions.config.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%    The diff tool is used to compare jena models and produce a result model which is the first model (minuend)      %>
+<%       with any matching statements in the second model (subtrahend) removed from it.                               %>
+<%    =====                                                                                                           %>
+<%    This tool produces the graph-math difference of the triples between two models. It produces a model with the    %>
+<%       triples which are in the minuend and not in the subtrahend.                                                  %>
+<%    Expressed mathematically as minuend - subtrahend = difference                                                   %>
+<%    Neither the minend nor the subtrahend are altered.                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Task>
+	<!--INPUT -->
+	<!--MINUEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="minuend"> The model described by this config file is the model which has the data which will be in   %>
+<%     output model.                                                                                                  %>
+<%                                                                                                                    %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="minuend">previous-harvest.model.xml</Param>
+
+	<!--VIVO -->
+	    <!--SUBTRAHEND : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="subtrahend"> The model described by this config file contains the triples which are not goning to    %>
+<%     be within the output model. If the triples match any within the minuend model then the output will be smaller  %>
+<%     than the minuend.                                                                                              %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="subtrahend">harvested-data.model.xml</Param>
+
+	<!-- OPTIONS -->
+	    <!--DUMPFILE -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="dumptofile"> This denotes the place for a text dump file to be produced. The default format of the   %>
+<%  dumpfile is RDF/XML and is able to be added or removed from another model through the use of the transfer tool.   %>
+<%  <Param name="dumptolanguage"> This denotes the language the rdf is in. Predefined values for lang are "RDF/XML",  %>
+<%  "N-TRIPLE", "TURTLE" (or "TTL") and "N3". * null represents the default language, "RDF/XML". "RDF/XML-ABBREV" is  %>
+<%  a synonym for "RDF/XML".					  																	  %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	<Param name="dumptofile">xmlrdf=data/vivo-subtractions.rdf.xml</Param>
+	<Param name="dumptofile">ntriple=data/vivo-ntriple-subtractions.xml</Param>
+	<Param name="dumptolanguage">ntriple=N-TRIPLE</Param>
+	
+	<!--OUTPUT : for more information please see the given config file -->
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="output"> The model described by this config file is the model that will be produced which will       %>
+<%     contain the data which is in the minuend but not in the subtrahend.                                            %>
+<%                                                                                                                    %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+<!--     <Param name="output">diff-output.model.xml</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="selective-diff"> Tells Diff to use the selectiveDiff method in execute. If any "update-types"	      %>
+<%  parameters (below) are set, this flag is implicitly set. This flag exists mostly for the case where one wishes    %>
+<%  to use selectiveDiff without specifying update types.                       				      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+	
+<!--     <Param name="selective-diff">T</Param> -->
+
+<!-- 
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  <Param name="update-types"> Each update-types entry specifies a type allowed to be updated in the process of      %>
+<%     a diff, meant primarily for creating subtraction models. Untested for addition models!		      	      %>
+<%														      %>
+<%     Specifying any type at all will cause Diff to use the selectiveDiff() method, leading to unspecified types     %>
+<%     being preserved.                                  							      %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+    
+	<!-- <Param name="update-types">http://xmlns.com/foaf/0.1/Person</Param> -->
+        <Param name="wordiness">INFO</Param> 
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/harvested-data.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/harvested-data.model.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Config>
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Models ===== 																									%>
+<%	type - defines which type of jena model																				%>
+<%		Possible Values:																								%>
+<%			<Param name="type">tdb</Param> - defines a tdb jena model													%>
+<%			<Param name="type">sdb</Param> - defines an sdb jena model													%>
+<%			<Param name="type">rdb</Param> - defines an rdb jena model													%>
+<%			<Param name="type">file</Param> - defines an rdf file to use as a model										%>
+<%																														%>
+<%	===== Model Parameters ===== 																						%>
+<%	dbDir - the directory to store a tdb model in 																		%>
+<%			(only needed when type is tdb)	 																			%>
+<%		Example Values:																									%>
+<%			<Param name="dbDir">/absolute/path/to/dir</Param> - An absolute path to a directory on						%>
+<%				linux/unix/macosx operating systems																		%>
+<%			<Param name="dbDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on					%>
+<%				a windows operating system																				%>
+<%			<Param name="dbDir">relative/path/to/dir</Param> - A path to a directory that is relative					%>
+<%				to the folder the shell was in when this command was executed											%>
+<%	=== 																												%>
+<%																														%>
+<%	file - the path to the file that contains rdf data 																	%>
+<%			(only needed when type is file) 																			%>
+<%		Example Values:																									%>
+<%			<Param name="file">/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf					%>
+<%				file on linux/unix/macosx operating systems																%>
+<%			<Param name="file">C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf						%>
+<%				file on a windows operating system																		%>
+<%			<Param name="file">relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is					%>
+<%				relative to the folder the shell was in when this command was executed									%>
+<%	=== 																												%>
+<%																														%>
+<%	rdfLang - the format of the rdf in the file																			%>
+<%			(optional, only used when type is file) 																	%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="rdfLang">RDF/XML</Param> - rdf/xml format											%>
+<%			<Param name="rdfLang">N3</Param> - n3 format																%>
+<%			<Param name="rdfLang">TTL</Param> - turtle/ttl format														%>
+<%			<Param name="rdfLang">N-TRIPLE</Param> - n-triple format													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbLayout - the layout to use for an sdb model 																		%>
+<%			(optional, only used when type is sdb) 																		%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="dbLayout">layout2</Param> - layout2													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbType - the name of the database type (as specified by jena) 														%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbType">MySQL</Param> - mysql database															%>
+<%			<Param name="dbType">H2</Param> - h2 database																%>
+<%	=== 																												%>
+<%																														%>
+<%	dbClass - the JDBC driver class to use 																				%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - mysql database										%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - h2 database													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUrl - the JDBC connection url 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database								%>
+<%				see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - h2 database											%>
+<%				see http://www.h2database.com/html/features.html#database_url											%>
+<%	=== 																												%>
+<%																														%>
+<%	modelName - the named model to use																					%>
+<%			(optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )					%>
+<%		Examples: 																										%>
+<%			<Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>							%>
+<%			<Param name="modelName">mySimpleModelName</Param>															%>
+<%			<Param name="modelName">http://vivo.localinstitution.edu/models/my-uri-model</Param>						%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUser - the DB username to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	=== 																												%>
+<%																														%>
+<%	dbPass - the DB password to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%																														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample tdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/tdb-jena-rh</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample file model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">file</Param>
+	<Param name="file">data/file-jena-rh.rdf.n3</Param>
+	<Param name="rdfLang">N3</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample rdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">rdb</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample sdb model																									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">sdb</Param>
+	<Param name="dbLayout">layout2</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/harvested-data/</Param>
+</Config>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/harvested-dump.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/harvested-dump.config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%                                                                                                                    %>
+<%  displayResultFormat - Since RDF can be expressed in several different format, this parameter is where the format  %>
+<%          is specified.                                                                                             %>
+<%          RS_XML RS_TEXT CSV RS_JSON RS_RDF  - for select                                                           %>
+<%          RDF/XML RDF/XML-ABBREV N3 N-TRIPLE TTL - for construct and describe                                       %>
+<%          <param name="queryResultFormat">RDF/XML</param>                                                           %>
+<%                                                                                                                    %>
+<%  outputfile - This specifies the output file for the results of the query. If it isn't specified then it is sent   %>
+<%          to the command line output.                                                                               %>
+<%          <param name="fileOutput">path/Filename</param>                                                            %>
+<%                                                                                                                    %>
+<%  dataset - This flag signals that the query should be done against the data set and not the model.                 %>
+<%          <param name="dataset">true</param>                                                                        %>
+<%                                                                                                                    %>
+
+-->
+<Config>
+    <Param name="wordiness">INFO</Param>
+    <Param name="jena">harvested-data.model.xml</Param>
+    <Param name="query">select ?s ?p ?o where { ?s ?p ?o }</Param>
+    <Param name="queryResultFormat">RS_RDF</Param>
+    <Param name="fileOutput">harvested-dump.rdf</Param>
+</Config>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/previous-harvest.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/previous-harvest.model.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Model>
+    <Param name="type">tdb</Param>
+    <Param name="dbDir">previous-harvest</Param>
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/pubmed-to-vivo.datamap.xsl
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/pubmed-to-vivo.datamap.xsl
@@ -1,0 +1,724 @@
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!-- <?xml version="1.0"?> -->
+<!-- Header information for the Style Sheet
+	The style sheet requires xmlns for each prefix you use in constructing
+	the new elements
+-->
+<xsl:stylesheet version="2.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:fn="http://www.w3.org/2005/xpath-functions"
+	xmlns:functx="http://www.functx.com"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:core="http://vivoweb.org/ontology/core#"
+	xmlns:vitro = "http://vitro.mannlib.cornell.edu/ns/vitro/0.7#"
+	xmlns:foaf="http://xmlns.com/foaf/0.1/"
+	xmlns:score='http://vivoweb.org/ontology/score#'
+	xmlns:bibo='http://purl.org/ontology/bibo/'
+	xmlns:obo = "http://purl.obolibrary.org/obo/"
+	xmlns:vcard = "http://www.w3.org/2006/vcard/ns#"
+	xmlns:rdfs='http://www.w3.org/2000/01/rdf-schema#'
+	xmlns:localVivo='http://vivo.sample.edu/ontology/'>
+
+	<!-- This will create indenting in xml readers -->
+	<xsl:output method="xml" indent="yes"/>
+	<xsl:variable name="baseURI">http://vivoweb.org/harvest/pubmed/</xsl:variable>
+    <xsl:function name="functx:substring-before-last-match" as="xs:string?"
+              xmlns:functx="http://www.functx.com">
+     <xsl:param name="arg" as="xs:string?"/>
+     <xsl:param name="regex" as="xs:string"/>
+
+     <xsl:sequence select="replace($arg,concat('^(.*)',$regex,'.*'),'$1')
+    "/>
+
+</xsl:function>
+	<!-- The main Article Set of all pubmed citations loaded 
+		This serves as the header of the RDF file produced
+	 -->
+	<xsl:template match="/PubmedArticleSet">
+		<rdf:RDF xmlns:owlPlus='http://www.w3.org/2006/12/owl2-xml#'
+			xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+			xmlns:skos='http://www.w3.org/2008/05/skos#'
+			xmlns:rdfs='http://www.w3.org/2000/01/rdf-schema#'
+			xmlns:owl='http://www.w3.org/2002/07/owl#'
+			xmlns:vocab='http://purl.org/vocab/vann/'
+			xmlns:swvocab='http://www.w3.org/2003/06/sw-vocab-status/ns#'
+			xmlns:dc='http://purl.org/dc/elements/1.1/'
+			xmlns:vitro='http://vitro.mannlib.cornell.edu/ns/vitro/0.7#' 
+			xmlns:core='http://vivoweb.org/ontology/core#'
+			xmlns:foaf='http://xmlns.com/foaf/0.1/'
+			xmlns:obo = "http://purl.obolibrary.org/obo/"
+			xmlns:vcard = "http://www.w3.org/2006/vcard/ns#"
+			xmlns:score='http://vivoweb.org/ontology/score#'
+			xmlns:xs='http://www.w3.org/2001/XMLSchema#'
+			xmlns:fn="http://www.w3.org/2005/xpath-functions"
+			xmlns:functx="http://www.functx.com"
+			xmlns:localVivo='http://vivo.sample.edu/ontology/'>
+			<xsl:apply-templates select="PubmedArticle" />
+			<xsl:apply-templates select="PubmedBookArticle" />
+		</rdf:RDF>
+	</xsl:template>
+	
+	<!-- The Article -->
+	<xsl:template match="PubmedArticle">
+		
+        <xsl:variable name="pmid" ><xsl:value-of select="MedlineCitation/PMID" /></xsl:variable>
+        
+		<rdf:Description rdf:about="{$baseURI}pub/pmid{child::MedlineCitation/PMID}">
+			<xsl:apply-templates select='MedlineCitation/Article/PublicationTypeList/PublicationType' />
+			 
+			<localVivo:harvestedBy>PubMed-Harvester</localVivo:harvestedBy>
+			<bibo:pmid><xsl:value-of select="MedlineCitation/PMID" /></bibo:pmid>
+			<rdfs:label><xsl:value-of select="MedlineCitation/Article/ArticleTitle" /></rdfs:label>
+			 
+			<!--  <score:Affiliation><xsl:value-of select="MedlineCitation/Article/Affiliation" /></score:Affiliation> -->
+			<bibo:volume><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/Volume"/></bibo:volume>
+			<bibo:number><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/Issue"/></bibo:number>
+			<bibo:abstract><xsl:value-of select="MedlineCitation/Article/Abstract"/></bibo:abstract>
+			
+			<xsl:apply-templates select="MedlineCitation/ChemicalList/Chemical" />
+			<!-- keywords -->
+			<xsl:apply-templates select="MedlineCitation/KeywordList/Keyword" />
+			<xsl:apply-templates  select="MedlineCitation/MeshHeadingList/MeshHeading" mode="termAsKeyword" />
+			
+			<xsl:choose>
+				<xsl:when test='string(PubmedData/ArticleIdList/ArticleId[@IdType="doi"])'>
+					<bibo:doi><xsl:value-of select='PubmedData/ArticleIdList/ArticleId[@IdType="doi"]' /></bibo:doi>
+				</xsl:when>
+			</xsl:choose>
+			<xsl:variable name="MonthNumber">
+				<xsl:choose>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Jan">01</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Feb">02</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Mar">03</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Apr">04</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=May">05</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Jun">06</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Jul">07</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Aug">08</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Sep">09</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Oct">10</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Nov">11</xsl:when>
+					<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month)=Dec">12</xsl:when>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:choose>
+				<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Year)">
+				    <core:dateTimeValue>
+                        <rdf:Description rdf:about="{$baseURI}pub/year{MedlineCitation/Article/Journal/JournalIssue/PubDate/Year}">
+					        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+					        <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearPrecision"/>
+	                        <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Year"/>-01-01T00:00:00</core:dateTime>
+				        </rdf:Description>
+                    </core:dateTimeValue>
+					<!-- <core:year rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear"><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Year"/></core:year> -->
+				</xsl:when>
+				<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month) and string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Year)">
+                    <core:dateTimeValue>
+                        <rdf:Description rdf:about="{$baseURI}pub/monthyear{$MonthNumber}{MedlineCitation/Article/Journal/JournalIssue/PubDate/Year}">
+	                        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+	                        <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearMonthPrecision"/>
+	                        <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber"/>-01T00:00:00</core:dateTime>
+                        </rdf:Description>
+                    </core:dateTimeValue>
+					<!-- <core:yearMonth rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth"><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber" /></core:yearMonth> -->
+				</xsl:when>
+				<xsl:when test="string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Day) and string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Month) and string(MedlineCitation/Article/Journal/JournalIssue/PubDate/Year)">
+					<core:dateTimeValue>
+                        <rdf:Description rdf:about="{$baseURI}pub/daymonthyear{MedlineCitation/Article/Journal/JournalIssue/PubDate/Day}{$MonthNumber}{MedlineCitation/Article/Journal/JournalIssue/PubDate/Year}">
+	                        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+	                        <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearMonthDayPrecision"/>
+	                        <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber"/>-<xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Day"/>T00:00:00</core:dateTime>
+                        </rdf:Description>
+                    </core:dateTimeValue>
+					<!-- <core:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber" />-<xsl:value-of select="MedlineCitation/Article/Journal/JournalIssue/PubDate/Day"/></core:date> -->
+				</xsl:when>
+			</xsl:choose>
+			<!-- parse page numbers: START -->
+			<bibo:pageStart><xsl:value-of select="substring-before(MedlineCitation/Article/Pagination/MedlinePgn, '-')" /></bibo:pageStart>
+			<xsl:variable name="pageStart"><xsl:value-of select="substring-before(MedlineCitation/Article/Pagination/MedlinePgn, '-')" /></xsl:variable>
+			<xsl:variable name="pageEnd"><xsl:value-of select="substring-after(MedlineCitation/Article/Pagination/MedlinePgn, '-')" /></xsl:variable>
+			<xsl:choose>
+				<xsl:when test="string-length($pageStart) &gt; string-length($pageEnd)">
+					<xsl:variable name="cutoff"><xsl:value-of select="(string-length($pageStart))-(string-length($pageEnd))+1" /></xsl:variable>
+					<bibo:pageEnd><xsl:value-of select="concat(substring($pageStart,0,$cutoff),$pageEnd)"/></bibo:pageEnd>
+				</xsl:when>
+				<xsl:when test="string-length($pageStart) &lt;= string-length($pageEnd)">
+					<bibo:pageEnd><xsl:value-of select="$pageEnd"/></bibo:pageEnd>
+				</xsl:when>
+			</xsl:choose>
+			<!-- parse page numbers: END -->
+			<xsl:apply-templates select="MedlineCitation/Article/AuthorList/Author" mode="authorRef" />
+			<xsl:apply-templates select="MedlineCitation/Article/Journal" mode="journalRef"/>
+		</rdf:Description>
+		
+		<xsl:apply-templates select="MedlineCitation/Article/AuthorList/Author" mode="fullAuthor" /> 
+		 
+		<xsl:apply-templates select="MedlineCitation/Article/Journal" mode="fullJournal" />
+	</xsl:template>
+	
+	<!-- The Book Article -->
+	<xsl:template match="PubmedBookArticle">
+	    <xsl:variable name="lastName" select="normalize-space(LastName)"/>
+        <xsl:variable name="firstName" select="normalize-space(ForeName)"/>    
+        <xsl:variable name="fullName"><xsl:value-of select = "$lastName" />, <xsl:value-of select = "$firstName" /></xsl:variable>
+        <xsl:variable name="pmid" select="ancestor::BookDocument/PMID" />
+        
+        <xsl:comment>book pmid is <xsl:value-of select="$pmid" /></xsl:comment>
+        
+		<rdf:Description rdf:about="{$baseURI}pub/pmid{child::BookDocument/PMID}">
+			<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" /> 
+			<localVivo:harvestedBy>PubMed-Harvester</localVivo:harvestedBy>
+			<bibo:pmid><xsl:value-of select="BookDocument/PMID" /></bibo:pmid>
+			<rdfs:label><xsl:value-of select="BookDocument/Book/BookTitle" /></rdfs:label>
+			<core:relatedBy rdf:resource="{$baseURI}authorship/pmid{$pmid}authorship{position()}" />  
+			<score:Affiliation><xsl:value-of select="BookDocument/Book/CollectionTitle" /></score:Affiliation>
+			<bibo:abstract><xsl:value-of select="BookDocument/Abstract"/></bibo:abstract>
+			<xsl:apply-templates select="BookDocument/KeywordList/Keyword" />
+			<xsl:choose>
+				<xsl:when test='string(PubmedData/ArticleIdList/ArticleId[@IdType="doi"])'>
+					<bibo:doi><xsl:value-of select='PubmedData/ArticleIdList/ArticleId[@IdType="doi"]' /></bibo:doi>
+				</xsl:when>
+			</xsl:choose>
+			<xsl:choose>
+				<xsl:when test='string(PubmedBookData/ArticleIdList/ArticleId[@IdType="doi"])'>
+					<bibo:doi><xsl:value-of select='PubmedBookData/ArticleIdList/ArticleId[@IdType="doi"]' /></bibo:doi>
+				</xsl:when>
+			</xsl:choose>
+			<xsl:variable name="MonthNumber">
+				<xsl:choose>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Jan">01</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Feb">02</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Mar">03</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Apr">04</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=May">05</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Jun">06</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Jul">07</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Aug">08</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Sep">09</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Oct">10</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Nov">11</xsl:when>
+					<xsl:when test="string(BookDocument/Book/PubDate/Month)=Dec">12</xsl:when>
+				</xsl:choose>
+			</xsl:variable>
+			<xsl:choose>
+				<xsl:when test="string(BookDocument/Book/PubDate/Year)">
+                    <core:dateTimeValue>
+                        <rdf:Description rdf:about="{$baseURI}pub/year{BookDocument/Book/PubDate/Year}">
+                            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+                            <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearPrecision"/>
+                            <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="BookDocument/Book/PubDate/Year"/>-01-01T00:00:00</core:dateTime>
+                        </rdf:Description>
+                    </core:dateTimeValue>
+<!-- 					<core:year rdf:datatype="http://www.w3.org/2001/XMLSchema#gYear"><xsl:value-of select="BookDocument/Book/PubDate/Year"/></core:year> -->
+				</xsl:when>
+				<xsl:when test="string(BookDocument/Book/PubDate/Month) and string(BookDocument/Book/PubDate/Year)">
+                    <core:dateTimeValue>
+                        <rdf:Description rdf:about="{$baseURI}pub/monthyear{$MonthNumber}{BookDocument/Book/PubDate/Year}">
+                            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+                            <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearMonthPrecision"/>
+                            <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="BookDocument/Book/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber"/>-01T00:00:00</core:dateTime>
+                        </rdf:Description>
+                    </core:dateTimeValue>
+<!-- 					<core:yearMonth rdf:datatype="http://www.w3.org/2001/XMLSchema#gYearMonth"><xsl:value-of select="BookDocument/Book/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber" /></core:yearMonth> -->
+				</xsl:when>
+				<xsl:when test="string(BookDocument/Book/PubDate/Day) and string(BookDocument/Book/PubDate/Month) and string(BookDocument/Book/PubDate/Year)">
+                    <core:dateTimeValue>
+                        <rdf:Description rdf:about="{$baseURI}pub/daymonthyear{MedlineCitation/Article/Journal/JournalIssue/PubDate/Day}{$MonthNumber}{BookDocument/Book/PubDate/Year}">
+                            <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+                            <core:dateTimePrecision rdf:resource="http://vivoweb.org/ontology/core#yearMonthDayPrecision"/>
+                            <core:dateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"><xsl:value-of select="BookDocument/Book/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber"/>-<xsl:value-of select="BookDocument/Book/PubDate/Day"/>T00:00:00</core:dateTime>
+                        </rdf:Description>
+                    </core:dateTimeValue>
+<!-- 					<core:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="BookDocument/Book/PubDate/Year"/>-<xsl:copy-of select="$MonthNumber" />-<xsl:value-of select="BookDocument/Book/PubDate/Day"/></core:date> -->
+				</xsl:when>
+			</xsl:choose>
+			<xsl:apply-templates select="BookDocument/Book/AuthorList/Author" mode="authorRef" />
+		</rdf:Description>
+		<xsl:apply-templates select="BookDocument/Book/AuthorList/Author" mode="fullAuthor" />
+	</xsl:template>
+
+	<xsl:template match="MedlineCitation/Article/Journal" mode="journalRef">
+		<core:hasPublicationVenue rdf:resource="{$baseURI}journal/journal{child::ISSN}" />
+	</xsl:template>
+
+<!-- The Main Journal Entity -->
+	<xsl:template match="MedlineCitation/Article/Journal" mode="fullJournal">
+		<rdf:Description rdf:about="{$baseURI}journal/journal{child::ISSN}" >
+			<localVivo:harvestedBy>PubMed-Harvester</localVivo:harvestedBy>
+			<rdf:type rdf:resource="http://purl.org/ontology/bibo/Journal" /> 
+			<rdfs:label><xsl:value-of select="Title" /></rdfs:label>
+			<bibo:issn><xsl:value-of select="ISSN"/></bibo:issn>
+			<core:publicationVenueFor rdf:resource="{$baseURI}pub/pmid{ancestor::MedlineCitation/PMID}"/>
+		</rdf:Description>	
+	</xsl:template>
+
+	<!-- Links to From the Article to the Terms and Authors -->
+	<xsl:template match="MedlineCitation/Article/AuthorList/Author" mode="authorRef"> 
+		<core:relatedBy rdf:resource="{$baseURI}authorship/pmid{ancestor::MedlineCitation/PMID}authorship{position()}" />
+	</xsl:template> 
+
+	<!-- Article Author List Navigation -->
+	<xsl:template match="MedlineCitation/Article/AuthorList/Author" mode="fullAuthor">
+	    
+	   <xsl:variable name="authorEmail" >
+	       <xsl:apply-templates select="AffiliationInfo/Affiliation" />
+		</xsl:variable>
+	    
+	    <xsl:variable name="lastName" select="normalize-space(LastName)"/>
+        <xsl:variable name="firstName" select="normalize-space(ForeName)"/>    
+        <xsl:variable name="fullName"><xsl:value-of select = "$lastName" />, <xsl:value-of select = "$firstName" /></xsl:variable>
+        <xsl:variable name="pmid" select="ancestor::MedlineCitation/PMID" />
+         
+	    <!-- authorship -->
+		<rdf:Description rdf:about="{$baseURI}authorship/pmid{ancestor::MedlineCitation/PMID}authorship{position()}">
+		   <localVivo:harvestedBy>PubMed-Harvester</localVivo:harvestedBy>
+			<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+			<vitro:mostSpecificType rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+			<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Relationship" />
+			<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+			<rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020" />
+			<rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001" />
+			<rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002" />
+			<xsl:choose>
+				<xsl:when test="$firstName">
+					<rdfs:label>Authorship for <xsl:value-of select = "$firstName" />, <xsl:value-of select = "$lastName" /></rdfs:label>
+				</xsl:when>
+				<xsl:when test="$lastName">
+					<rdfs:label>Authorship for <xsl:value-of select="$lastName" /></rdfs:label>
+				</xsl:when> 
+			</xsl:choose>
+			<core:relates rdf:resource="{$baseURI}author/pmid{$pmid}author{position()}" />
+			<core:relates rdf:resource="{$baseURI}pub/pmid{$pmid}" />
+			<core:authorRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int"><xsl:value-of select="position()" /></core:authorRank>
+		</rdf:Description>
+		
+		<!-- author -->
+		<rdf:Description rdf:about="{$baseURI}author/pmid{ancestor::MedlineCitation/PMID}author{position()}">
+		   <rdf:type rdf:resource = "http://xmlns.com/foaf/0.1/Person"/>
+           <vitro:mostSpecificType rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+           <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$fullName" /></rdfs:label>
+           <obo:ARG_2000028 rdf:resource="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcard{position()}"/>
+		</rdf:Description>
+		
+		<!-- vcard -->
+		<rdf:Description rdf:about="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcard{position()}">
+		   <obo:ARG_2000029 rdf:resource="{$baseURI}author/pmid{ancestor::MedlineCitation/PMID}author{position()}"/>
+           <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+           <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+           <rdf:type rdf:resource="http://purl.obolibrary.org/obo/ARG_2000379"/>
+           <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard for: <xsl:value-of select = "$fullName" /></rdfs:label>
+           <vcard:hasName rdf:resource="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardName{position()}"/>
+           <xsl:if test="normalize-space($authorEmail)" >
+           <vcard:hasEmail rdf:resource="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardEmail{position()}"/>
+           </xsl:if>
+		</rdf:Description>
+		
+		<!-- vcard name -->
+		<rdf:Description rdf:about="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardName{position()}">
+		   <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/> 
+           <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
+           <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard name for: <xsl:value-of select = "$fullName" /></rdfs:label>
+           <vcard:givenName rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$firstName" /></vcard:givenName>     
+           <vcard:familyName rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$lastName" /></vcard:familyName>
+		</rdf:Description>
+		
+		<!-- vcard email -->
+		 <xsl:if test="normalize-space($authorEmail)" >
+	     <rdf:Description rdf:about="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardEmail{position()}">
+	       <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Email"/>
+	       <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Work"/>
+	       <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Email"/>
+	       <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard email for: <xsl:value-of select = "$fullName" /></rdfs:label>
+	       <vcard:email rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$authorEmail" /></vcard:email>  
+	     </rdf:Description>
+	     </xsl:if>
+	</xsl:template> 
+	
+	<xsl:template match="AffiliationInfo/Affiliation">
+	   <xsl:choose>
+			<xsl:when test="normalize-space(.)" >
+				<xsl:analyze-string select="string(.)" regex="\s*([a-zA-Z\d\.]*@[a-zA-Z\d\.]*)"> 
+				  
+					<xsl:matching-substring>
+					<xsl:choose>
+					<xsl:when test="fn:ends-with(regex-group(1), '.')">
+					<xsl:value-of select="functx:substring-before-last-match(regex-group(1), '.')" />  
+					</xsl:when> 
+					<xsl:otherwise><xsl:value-of select="regex-group(1)" /></xsl:otherwise> 
+					</xsl:choose>   
+					</xsl:matching-substring>
+								
+				</xsl:analyze-string>
+			</xsl:when>
+			<xsl:otherwise></xsl:otherwise>
+			</xsl:choose>
+	</xsl:template>
+	
+	<!-- Links to From the Book to the Terms and Authors -->
+	<xsl:template match="BookDocument/Book/AuthorList/Author" mode="authorRef">
+		<core:relatedBy rdf:resource="{$baseURI}authorship/pmid{ancestor::MedlineCitation/PMID}authorship{position()}" />
+	</xsl:template>
+
+	<!-- Book Author List Navigation --> 
+	<xsl:template match="BookDocument/Book/AuthorList/Author" mode="fullAuthor">
+	    <xsl:variable name="lastName" select="normalize-space(LastName)"/>
+        <xsl:variable name="firstName" select="normalize-space(ForeName)"/>    
+        <xsl:variable name="fullName"><xsl:value-of select = "$lastName" />, <xsl:value-of select = "$firstName" /></xsl:variable>
+        <xsl:variable name="pmid" select="ancestor::MedlineCitation/PMID" />
+        <xsl:variable name="authorEmail" >
+	       <xsl:apply-templates select="AffiliationInfo/Affiliation" />
+		</xsl:variable>
+		
+		<!-- authorship -->
+		<rdf:Description rdf:about="{$baseURI}authorship/pmid{ancestor::BookDocument/PMID}authorship{position()}">
+			<localVivo:harvestedBy>PubMed-Harvester</localVivo:harvestedBy>
+			<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+			<vitro:mostSpecificType rdf:resource="http://vivoweb.org/ontology/core#Authorship" />
+			<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Relationship" />
+			<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+			<rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020" />
+			<rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001" />
+			<rdf:type rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002" />
+			<xsl:choose>
+				<xsl:when test="$firstName">
+					<rdfs:label>Authorship for <xsl:value-of select = "$firstName" />, <xsl:value-of select = "$lastName" /></rdfs:label>
+				</xsl:when>
+				<xsl:when test="$lastName">
+					<rdfs:label>Authorship for <xsl:value-of select="$lastName" /></rdfs:label>
+				</xsl:when> 
+			</xsl:choose>
+			<core:relates rdf:resource="{$baseURI}author/pmid{$pmid}author{position()}" />
+			<core:relates rdf:resource="{$baseURI}pub/pmid{$pmid}" />
+			<core:authorRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int"><xsl:value-of select="position()" /></core:authorRank>			
+		</rdf:Description>
+		
+		<!-- author -->
+		<rdf:Description rdf:about="{$baseURI}author/pmid{ancestor::MedlineCitation/PMID}author{position()}">
+		   <rdf:type rdf:resource = "http://xmlns.com/foaf/0.1/Person"/>
+           <vitro:mostSpecificType rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+           <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$fullName" /></rdfs:label>
+           <obo:ARG_2000028 rdf:resource="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcard{position()}"/>
+		</rdf:Description>
+		
+		<!-- vcard -->
+		<rdf:Description rdf:about="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcard{position()}">
+		   <obo:ARG_2000029 rdf:resource="{$baseURI}author/pmid{ancestor::MedlineCitation/PMID}author{position()}"/>
+           <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+           <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Individual"/>
+           <rdf:type rdf:resource="http://purl.obolibrary.org/obo/ARG_2000379"/>
+           <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard for: <xsl:value-of select = "$fullName" /></rdfs:label>
+           <vcard:hasName rdf:resource="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardName{position()}"/>
+           <xsl:if test="normalize-space($authorEmail)" >
+           <vcard:hasEmail rdf:resource="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardEmail{position()}"/>
+           </xsl:if>
+		</rdf:Description>
+		
+		<!-- vcard name -->
+		<rdf:Description rdf:about="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardName{position()}">
+		   <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/> 
+           <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Name"/>
+           <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard name for: <xsl:value-of select = "$fullName" /></rdfs:label>
+           <vcard:givenName rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$firstName" /></vcard:givenName>     
+           <vcard:familyName rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$lastName" /></vcard:familyName>
+		</rdf:Description>
+		
+		<!-- vcard email -->
+		 <xsl:if test="normalize-space($authorEmail)" >
+	     <rdf:Description rdf:about="{$baseURI}vcard/pmid{ancestor::MedlineCitation/PMID}vcardEmail{position()}">
+	       <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Email"/>
+	       <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Work"/>
+	       <vitro:mostSpecificType rdf:resource="http://www.w3.org/2006/vcard/ns#Email"/>
+	       <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vCard email for: <xsl:value-of select = "$fullName" /></rdfs:label>
+	       <vcard:email rdf:datatype="http://www.w3.org/2001/XMLSchema#string"><xsl:value-of select = "$authorEmail" /></vcard:email>  
+	     </rdf:Description>
+	     </xsl:if>
+			
+			<!-- <rdf:type rdf:resource="http://vivoweb.org/harvester/excludeEntity" /> 
+			<core:authorInAuthorship rdf:resource="{$baseURI}authorship/pmid{ancestor::BookDocument/PMID}authorship{position()}" /> -->
+		 
+	</xsl:template>
+	
+	<xsl:template match="MedlineCitation/MeshHeadingList/MeshHeading" mode="termAsKeyword">
+		<xsl:choose>
+			<xsl:when test="string(DescriptorName)">
+				<core:freetextKeyword><xsl:value-of select="string(DescriptorName)" /></core:freetextKeyword>  
+			</xsl:when>
+		</xsl:choose>	
+	</xsl:template>	
+	
+	<!-- Chemical List -->
+	<xsl:template match="MedlineCitation/ChemicalList/Chemical">
+		<xsl:if test="normalize-space(.)">
+			<core:freetextKeyword><xsl:value-of select="." /></core:freetextKeyword>
+		</xsl:if>
+	</xsl:template>
+	
+	<!-- Article Keyword -->
+	 
+	
+	<xsl:template match="MedlineCitation/KeywordList/Keyword">
+	    <xsl:if test="normalize-space(.)" > 
+		<core:freetextKeyword><xsl:value-of select="." /></core:freetextKeyword>
+		</xsl:if>
+	</xsl:template>
+	
+	<!-- Book Keyword -->
+	<xsl:template match="BookDocument/KeywordList/Keyword">
+		<xsl:if test="normalize-space(.)">
+			<core:freetextKeyword><xsl:value-of select="." /></core:freetextKeyword>  
+		</xsl:if>
+	</xsl:template>
+	
+	<!-- Types -->
+	<xsl:template match="MedlineCitation/Article/PublicationTypeList/PublicationType">
+		<xsl:variable name="up" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ '"/>
+		<xsl:variable name="lo" select="'abcdefghijklmnopqrstuvwxyz '"/>
+		<xsl:variable name="pbType" select="string(self::PublicationType)" />
+		<xsl:choose>
+			<xsl:when test="translate(string($pbType),$up,$lo)='addresses'">
+				<rdf:type rdf:resource="http://vivoweb.org/ontology/core#ConferencePaper" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='atlases'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='bibliography'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='biobibliography'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='biography'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='book reviews'">
+				<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Review" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='case reports'">
+				<rdf:type rdf:resource="http://vivoweb.org/ontology/core#CaseStudy" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='charts'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Image" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='classical article'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='clinical conference'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='clinical trial'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='clinical trial, phase i'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='clinical trial, phase ii'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='clinical trial, phase iii'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='clinical trial, phase iv'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='collected correspondence'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='collected works'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='comment'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='comparative study'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='congresses'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Proceedings" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='consensus development conference'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Proceedings" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='consensus development conference, nih'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Proceedings" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='controlled clinical trial'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='cookbooks'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='corrected and republished article'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='database'">
+				<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Database" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='diaries'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='dictionary'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='directory'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='documentaries and factual films'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Film" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='drawings'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Image" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='duplicate publication'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='editorial'">
+				<rdf:type rdf:resource="http://vivoweb.org/ontology/core#EditorialArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='encyclopedias'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='essays'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>			
+			<xsl:when test="translate(string($pbType),$up,$lo)='evaluation studies'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='festschrift'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='fictional work'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='formularies'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<!-- Government Publications -->
+			<xsl:when test="translate(string($pbType),$up,$lo)='guidebooks'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='guideline'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Standard" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='handbooks'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='historical article'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='incunabula'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='indexes'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='instruction'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AudioVisualDocument" />
+			</xsl:when>
+			<!-- Interactive Tutorial -->
+			<xsl:when test="translate(string($pbType),$up,$lo)='interview'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='introductory journal article'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate($pbType,$up,$lo)='journal article'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<!-- Lectures -->
+			<xsl:when test="translate(string($pbType),$up,$lo)='legal cases'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/LegalCaseDocument" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='legislation'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Legislation" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='maps'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Map" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='meeting abstracts'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ConferenceProceedings" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='meta-analysis'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='multicenter study'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='news'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='newspaper article'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='patents'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Patent" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='patient education handout'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Document" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='periodical index'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='periodicals'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Periodicals" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='pharmacopoeias'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/ReferenceSource" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='pictorial works'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='portraits'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Image" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='practice guideline'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Standard" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='randomized controlled trial'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='review'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+				<rdf:type rdf:resource="http://vivoweb.org/ontology/core#Review" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='statistics'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='study characteristics'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='technical report'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Report" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='textbooks'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Book" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='twin study'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<xsl:when test="translate(string($pbType),$up,$lo)='validation studies'">
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/AcademicArticle" />
+			</xsl:when>
+			<!--  Webcasts -->
+			<xsl:otherwise>
+				<rdf:type rdf:resource="http://purl.org/ontology/bibo/Document" />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	
+	 
+
+</xsl:stylesheet>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/pubmedfetch.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/pubmedfetch.config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task >
+   <Param name="wordiness">DEBUG</Param>
+   <Param name="email">jaf30@cornell.edu</Param>
+   <Param name="termSearch">0000-0002-1825-0097[Author Identifier]</Param>
+   <Param name="numRecords">100</Param>
+   <Param name="batchSize">100</Param>
+   <Param name="output">raw-records.config.xml</Param>
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/raw-records.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/raw-records.config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<RecordHandler>
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+<!--  <Param name="type">tdb</Param> -->
+	<Param name="fileDir">data/raw-records</Param>
+</RecordHandler>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/remove-last-pubmed-harvest.sh
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/remove-last-pubmed-harvest.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+#All rights reserved.
+#This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+
+# set to the directory where the harvester was installed or unpacked
+# HARVESTER_INSTALL_DIR is set to the location of the installed harvester
+#	If the deb file was used to install the harvester then the
+#	directory should be set to /usr/share/vivo/harvester which is the
+#	current location associated with the deb installation.
+#	Since it is also possible the harvester was installed by
+#	uncompressing the tar.gz the setting is available to be changed
+#	and should agree with the installation location
+HARVESTER_INSTALL_DIR=/usr/local/src/VIVO-Harvester
+export HARVEST_NAME=example-pubmed
+export DATE=`date +%Y-%m-%d'T'%T`
+
+# Add harvester binaries to path for execution
+# The tools within this script refer to binaries supplied within the harvester
+#	Since they can be located in another directory their path should be
+#	included within the classpath and the path enviromental variables.
+export PATH=$PATH:$HARVESTER_INSTALL_DIR/bin
+export CLASSPATH=$CLASSPATH:$HARVESTER_INSTALL_DIR/bin/harvester.jar:$HARVESTER_INSTALL_DIR/bin/dependency/*
+export CLASSPATH=$CLASSPATH:$HARVESTER_INSTALL_DIR/build/harvester.jar:$HARVESTER_INSTALL_DIR/build/dependency/*
+
+# Exit on first error
+# The -e flag prevents the script from continuing even though a tool fails.
+#	Continuing after a tool failure is undesirable since the harvested
+#	data could be rendered corrupted and incompatible.
+set -e
+
+# Supply the location of the detailed log file which is generated during the script.
+#	If there is an issue with a harvest, this file proves invaluable in finding
+#	a solution to the problem. I has become common practice in addressing a problem
+#	to request this file. The passwords and user-names are filter out of this file
+#	To prevent these logs from containing sensitive information.
+echo "Full Logging in $HARVEST_NAME.$DATE.log"
+
+# Be aware that the additions file may have data which was duplicating existing triples and
+#	removing the additions file will result in removing the previously existing triples.
+#	To prevent post-removal data issues inspections and edits of the additions may need
+#	to be done.
+
+
+echo "addition node count to be removed: " `grep -c "<rdf:Description" data/vivo-additions.rdf.xml`
+
+echo "subtraction node count to be added: " `grep -c "<rdf:Description" data/vivo-subtractions.rdf.xml`
+
+# During the reverse process the previous harvest model needs to be adjusted when the
+#	vivo model is also adjusted. This keeps the previous model as a mirror of the changes
+#	the the harvester has ever done to the vivo model. 
+# Remove Additions from Previous model
+harvester-transfer -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml -R RDF/XML -m
+
+# Remove Subtractions from Previous model
+harvester-transfer -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -R RDF/XML 
+
+# Now that the changes have been applied to the previous harvest and the harvested data in vivo
+#	should agree with the previous harvest, the changes are now applied to the vivo model.
+# Remove Additions from VIVO for pre-1.2 versions
+harvester-transfer -o vivo.model.xml -r data/vivo-additions.rdf.xml -R RDF/XML -m
+
+# Remove Subtractions from VIVO for pre-1.2 versions
+harvester-transfer -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -R RDF/XML
+
+echo 'Harvest reversal completed successfully'

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/run-pubmed.sh
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/run-pubmed.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+if [[ "$1" != "" && "$1" != "tdb" && "$1" != "sparql" ]]; then
+  echo "Invalid argument: $1"
+  echo "Usage: $0 [tdb|sparql]"
+  exit 1
+fi
+
+# Set environment variables
+export HARVESTER_INSTALL_DIR=/usr/local/src/VIVO-Harvester
+export HARVEST_NAME=example-pubmed
+export DATE=`date +%Y-%m-%d'T'%T`
+
+# Add harvester binaries to path
+export PATH=$PATH:$HARVESTER_INSTALL_DIR/bin
+export CLASSPATH=$CLASSPATH:$HARVESTER_INSTALL_DIR/bin/harvester.jar:$HARVESTER_INSTALL_DIR/bin/dependency/*
+export CLASSPATH=$CLASSPATH:$HARVESTER_INSTALL_DIR/build/harvester.jar:$HARVESTER_INSTALL_DIR/build/dependency/*
+
+set -e  # Exit on first error
+
+# Logging setup
+echo "Full Logging in $HARVEST_NAME.$DATE.log"
+mkdir -p logs
+cd logs
+touch $HARVEST_NAME.$DATE.log
+ln -sf $HARVEST_NAME.$DATE.log $HARVEST_NAME.latest.log
+cd ..
+
+# Clear old data
+rm -rf data
+
+# Execute Fetch
+harvester-pubmedhttpfetch -X pubmedfetch.config.xml
+
+# Execute Translate
+harvester-xsltranslator -X xsltranslator.config.xml
+
+# Execute Transfer to import from record handler into local temp model
+harvester-transfer -w INFO -s translated-records.config.xml -o harvested-data.model.xml -d data/harvested-data/imported-records.rdf.xml
+
+# Find Subtractions
+harvester-diff -X diff-subtractions.config.xml
+
+# Find Additions
+harvester-diff -X diff-additions.config.xml
+
+# Apply Subtractions to Previous model
+harvester-transfer -w INFO -o previous-harvest.model.xml -r data/vivo-subtractions.rdf.xml -m
+
+# Apply Additions to Previous model
+harvester-transfer -w INFO -o previous-harvest.model.xml -r data/vivo-additions.rdf.xml
+
+## Apply changes to VIVO model
+if [[ "$1" == "tdb" ]]; then
+  # Apply Subtractions to VIVO model
+  harvester-transfer -w info -o vivo.model.xml -r data/vivo-subtractions.rdf.xml -m
+  # Apply Additions to VIVO model
+  harvester-transfer -w info -o vivo.model.xml -r data/vivo-additions.rdf.xml
+fi
+
+if [[ "$1" == "" || "$1" == "sparql" ]]; then
+  java $HARVESTER_JAVA_OPTS org.vivoweb.harvester.services.SparqlUpdate -X sparqlupdate.conf.xml
+fi
+
+# Output counts
+PUBS=`grep -c oai data/vivo-additions.rdf.xml`
+AUTHORS=`grep -c 'http://xmlns.com/foaf/0.1/Person' data/vivo-additions.rdf.xml`
+AUTHORSHIPS=`grep -c Authorship data/vivo-additions.rdf.xml`
+echo "Imported $PUBS publications, $AUTHORS authors, and $AUTHORSHIPS authorships"
+
+echo 'Harvest completed successfully'

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/sparqlupdate.conf.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/sparqlupdate.conf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <Param name="wordiness">INFO</Param>
+    <!-- input -->
+    <Param name="rdf">data/vivo-additions.rdf.xml</Param>
+    <Param name="type">add</Param>
+    <!-- output -->
+
+    <Param name="url">http://localhost:8080/vivo/api/sparqlUpdate</Param>
+    <Param name="model">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>
+    <Param name="username">vivo_root@mydomain.edu</Param>
+    <Param name="password">admin123</Param>
+
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/transfer.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/transfer.config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+    <!-- 
+    wordiness - how much should be displayed on the console when the fetch is run.  Options range from nothing at all to errors only to general
+    information to more detailed debugging information.
+    -
+    Allowable values:
+    OFF - No log information is displayed on the console.
+    ERROR - All error messages are displayed. 
+    WARN - Error and warning messages are displayed.
+    INFO - Errors, warnings, and general user information is displayed.  This is the default.
+    DEBUG - Errors, warnings, general information, and information intended for debuggers is displayed to the console.
+    TRACE - All of the above as well as even finer-grain debugging information is displayed.
+    ALL - Everything that goes into the log is displayed on the console.
+
+    Values meaningful for Transfer:
+    ERROR - All runtime errors
+    DEBUG - Warning if no output is specified
+    -->
+    <Param name="wordiness">INFO</Param>
+
+    <!-- 
+    recordHandler - relative path to the configuration file of the record handler from which we are drawing our input
+    -->
+    <Param name="recordHandler">translated-records.config.xml</Param>
+
+    <!-- 
+    output - relative path to the configuration file for the Jena model to output triples to (or to remove triples from).
+    -->
+    <Param name="output">harvested-data.model.xml</Param>
+    <Param name="dumptofile">data/harvested-data/imported-records.rdf.xml</Param>
+    <Param name="wordiness">INFO</Param>    
+</Task>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/translated-records.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/translated-records.config.xml
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<RecordHandler>
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Record Sets =====																								%>
+<%	rhClass - The class for the handler for this record set																%>
+<%		Example Values:																									%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>							%>
+<%			 - to store each record as a file in a folder (specified by fileDir). NOTE: performance with				%>
+<%				TextFileRecordHandler is quite poor, but is the suggested while building and testing your				%>
+<%				script. Once the script works, switch to using a higher performance recordhandler like					%>
+<%				JDBCRecordHandler (in an h2 database) or JenaRecordHandler (in a tdb model).							%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>								%>
+<%			 - to store each record in a table in a relational database (specified with dbClass, dbUrl, dbUser,			%>
+<%				dbPass, dbTable, and dataFieldName)																		%>
+<%			<Param name="rhClass">org.vivoweb.harvester.util.repo.JenaRecordHandler</Param>								%>
+<%			 - to store each record in a jena triple store (specified with dataFieldType, jenaConfig, and/or			%>
+<%				all the parameters for a jena model (see below)															%>
+<%																														%>
+<%	===== TextFileRecordHandler Parameters =====																		%>
+<%	fileDir - the directory in which to store the files for each record													%>
+<%		Example Values:																									%>
+<%			<Param name="fileDir">/absolute/path/to/dir</Param> - An absolute path to a directory on linux/unix/macosx	%>
+<%				operating systems																						%>
+<%			<Param name="fileDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on a windows		%>
+<%				operating system																						%>
+<%			<Param name="fileDir">relative/path/to/dir</Param> - A path to a directory that is relative to the folder	%>
+<%				the shell was in when this command was executed															%>
+<%																														%>
+<%	===== JDBCRecordHandler Parameters =====																			%>
+<%	dbClass - the JDBC driver class to use																				%>
+<%		Example Values:																									%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - for a mysql database									%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - for an h2 database											%>
+<%	===																													%>
+<%																														%>
+<%	dbUrl - the JDBC connection url																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - for a mysql database.						%>
+<%				See http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - for an h2 database.									%>
+<%				See http://www.h2database.com/html/features.html#database_url											%>
+<%	===																													%>
+<%																														%>
+<%	dbUser - the DB username to use																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	===																													%>
+<%																														%>
+<%	dbPass - the DB password to use																						%>
+<%		Example Values:																									%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%	===																													%>
+<%																														%>
+<%	dbTable - (optional) the name of the table to store data in, if non-existent will be created						%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dbTable">recordTable</Param>															%>
+<%			<Param name="dbTable">myTableName</Param>																	%>
+<%	===																													%>
+<%																														%>
+<%	dataFieldName - (optional) the name of the field to use, if table is non-existent will be created with table		%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dataFieldName">dataField</Param>														%>
+<%			<Param name="dataFieldName">myDataFieldName</Param>															%>
+<%																														%>
+<%	===== JenaRecordHandler Parameters =====																			%>
+<%	dataFieldType - (optional) the predicate to use for storing data properties											%>
+<%		Example Values:																									%>
+<%			(default) <Param name="dataFieldType">http://vivoweb.org/harvester/rh#dataFieldType</Param>					%>
+<%			<Param name="dataFieldType">http://yourmom.com/propbase#myProp</Param>										%>
+<%	===																													%>
+<%																														%>
+<%	jenaConfig - (optional - at least one of this and/or full set of params defining a model as described in Models		%>
+<%			section below) the configuration file that describes the model in which to store data. The parameters for	%>
+<%			this config file are described in the Models section below.													%>
+<%		Example Values:																									%>
+<%			<Param name="jenaConfig">/absolute/path/to/jena-model.config.xml</Param> - An absolute path					%>
+<%				to a directory on linux/unix/macosx operating systems													%>
+<%			<Param name="jenaConfig">C:/absolute/path/to/jena-model.config.xml</Param> - An absolute					%>
+<%				path to a directory on a windows operating system														%>
+<%			<Param name="jenaConfig">relative/path/to/jena-model.config.xml</Param> - A path to a						%>
+<%				directory that is relative to the folder the shell was in when this command was executed				%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample TextFileRecordHandler																						%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<Param name="fileDir">data/tf-rh</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JDBCRecordHandler - using h2 database and default dbTable and dataFieldName									%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/h2-jdbc-rh/store</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JDBCRecordHandler - using mysql database and custom dbTable and dataFieldName								%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JDBCRecordHandler</Param>
+	<Param name="dbClass">com.mysql.jdbc.Driver</Param>
+	<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param>
+	<Param name="dbUser">myUser</Param>
+	<Param name="dbPass">myPass</Param>
+	<Param name="dbTable">myTableName</Param>
+	<Param name="dataFieldName">myDataFieldName</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - just base params																			%>
+<%		(using inline model configs as below the Models section or config file as defined below)						%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.JenaRecordHandler</Param>
+	<Param name="dataFieldType">http://yourmom.com/propbase#myProp</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an external model config file														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="jenaConfig">jena-model.conf.xml</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	===== Models ===== 																									%>
+<%	type - defines which type of jena model																				%>
+<%		Possible Values:																								%>
+<%			<Param name="type">tdb</Param> - defines a tdb jena model													%>
+<%			<Param name="type">sdb</Param> - defines an sdb jena model													%>
+<%			<Param name="type">rdb</Param> - defines an rdb jena model													%>
+<%			<Param name="type">file</Param> - defines an rdf file to use as a model										%>
+<%																														%>
+<%	===== Model Parameters ===== 																						%>
+<%	checkEmpty - (optional) check if the model is empty and log a warning if it is										%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="checkEmpty">false</Param> - don't check and don't log a message						%>
+<%			<Param name="checkEmpty">true</Param> - check if empty and log a warn log message if empty					%>
+<%	=== 																												%>
+<%																														%>
+<%	dbDir - the directory to store a tdb model in 																		%>
+<%			(only needed when type is tdb)	 																			%>
+<%		Example Values:																									%>
+<%			<Param name="dbDir">/absolute/path/to/dir</Param> - An absolute path to a directory on						%>
+<%				linux/unix/macosx operating systems																		%>
+<%			<Param name="dbDir">C:/absolute/path/to/dir</Param> - An absolute path to a directory on					%>
+<%				a windows operating system																				%>
+<%			<Param name="dbDir">relative/path/to/dir</Param> - A path to a directory that is relative					%>
+<%				to the folder the shell was in when this command was executed											%>
+<%	=== 																												%>
+<%																														%>
+<%	file - the path to the file that contains rdf data 																	%>
+<%			(only needed when type is file) 																			%>
+<%		Example Values:																									%>
+<%			<Param name="file">/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf					%>
+<%				file on linux/unix/macosx operating systems																%>
+<%			<Param name="file">C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf						%>
+<%				file on a windows operating system																		%>
+<%			<Param name="file">relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is					%>
+<%				relative to the folder the shell was in when this command was executed									%>
+<%	=== 																												%>
+<%																														%>
+<%	rdfLang - the format of the rdf in the file																			%>
+<%			(optional, only used when type is file) 																	%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="rdfLang">RDF/XML</Param> - rdf/xml format											%>
+<%			<Param name="rdfLang">N3</Param> - n3 format																%>
+<%			<Param name="rdfLang">TTL</Param> - turtle/ttl format														%>
+<%			<Param name="rdfLang">N-TRIPLE</Param> - n-triple format													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbLayout - the layout to use for an sdb model 																		%>
+<%			(optional, only used when type is sdb) 																		%>
+<%		Possible Values:																								%>
+<%			(default) <Param name="dbLayout">layout2</Param> - layout2													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbType - the name of the database type (as specified by jena) 														%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbType">MySQL</Param> - mysql database															%>
+<%			<Param name="dbType">H2</Param> - h2 database																%>
+<%	=== 																												%>
+<%																														%>
+<%	dbClass - the JDBC driver class to use 																				%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbClass">com.mysql.jdbc.Driver</Param> - mysql database										%>
+<%			<Param name="dbClass">org.h2.Driver</Param> - h2 database													%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUrl - the JDBC connection url 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Examples: 																										%>
+<%			<Param name="dbUrl">jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database								%>
+<%				see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html			%>
+<%			<Param name="dbUrl">jdbc:h2:path/to/h2/store</Param> - h2 database											%>
+<%				see http://www.h2database.com/html/features.html#database_url											%>
+<%	=== 																												%>
+<%																														%>
+<%	modelName - the named model to use																					%>
+<%			(optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )					%>
+<%		Examples: 																										%>
+<%			<Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>							%>
+<%			<Param name="modelName">mySimpleModelName</Param>															%>
+<%			<Param name="modelName">http://vivo.localinstitution.edu/models/my-uri-model</Param>						%>
+<%	=== 																												%>
+<%																														%>
+<%	dbUser - the DB username to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbUser">sa</Param> - used for h2 database (the default h2 system admin login					%>
+<%			<Param name="dbUser">myUser</Param>																			%>
+<%	=== 																												%>
+<%																														%>
+<%	dbPass - the DB password to use 																					%>
+<%			(only needed when type is rdb or sdb)																		%>
+<%		Example: 																										%>
+<%			<Param name="dbPass"></Param> - used for h2 database (the default h2 system admin login						%>
+<%			<Param name="dbPass">myPass</Param>																			%>
+<%																														%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined tdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">tdb</Param>
+	<Param name="dbDir">data/tdb-jena</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined file model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">file</Param>
+	<Param name="file">data/file-jena.rdf.n3</Param>
+	<Param name="rdfLang">N3</Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined rdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">rdb</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+<!--
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+<%	Sample JenaRecordHandler - using an internally defined sdb model													%>
+<%		(using rhClass and dataFieldType as defined above the Models section)											%>
+<%	++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++	%>
+-->
+<!--
+	<Param name="type">sdb</Param>
+	<Param name="dbLayout">layout2</Param>
+	<Param name="dbType">H2</Param>
+	<Param name="dbClass">org.h2.Driver</Param>
+	<Param name="dbUrl">jdbc:h2:data/jena-model/store</Param>
+	<Param name="modelName">mySimpleModelName</Param>
+	<Param name="dbUser">sa</Param>
+	<Param name="dbPass"></Param>
+-->
+	<Param name="rhClass">org.vivoweb.harvester.util.repo.TextFileRecordHandler</Param>
+	<!-- <Param name="type">tdb</Param> -->
+	<Param name="fileDir">data/translated-records</Param>
+</RecordHandler>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/vivo.model.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/vivo.model.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<!--
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+<%  ===== Models =====                                                                                                  %>
+<%  type - defines which type of jena model                                                                             %>
+<%      Possible Values:                                                                                                %>
+<%          <Param name="scoreOverride">type=tdb</Param> - defines a tdb jena model                                     %>
+<%          <Param name="scoreOverride">type=sdb</Param> - defines an sdb jena model                                    %>
+<%          <Param name="scoreOverride">type=rdb</Param> - defines an rdb jena model                                    %>
+<%          <Param name="scoreOverride">type=file</Param> - defines an rdf file to use as a model                       %>
+<%                                                                                                                      %>
+<%  ===== Model Parameters =====                                                                                        %>
+<%  dbDir - the directory to store a tdb model in                                                                       %>
+<%          (only needed when type is tdb)                                                                              %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">dbDir=/absolute/path/to/dir</Param> - An absolute path to a directory on        %>
+<%              linux/unix/macosx operating systems                                                                     %>
+<%          <Param name="scoreOverride">dbDir=C:/absolute/path/to/dir</Param> - An absolute path to a directory on      %>
+<%              a windows operating system                                                                              %>
+<%          <Param name="scoreOverride">dbDir=relative/path/to/dir</Param> - A path to a directory that is relative     %>
+<%              to the folder the shell was in when this command was executed                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  file - the path to the file that contains rdf data                                                                  %>
+<%          (only needed when type is file)                                                                             %>
+<%      Example Values:                                                                                                 %>
+<%          <Param name="scoreOverride">file=/absolute/path/to/rdf-data.rdf.xml</Param> - An absolute path to an rdf    %>
+<%              file on linux/unix/macosx operating systems                                                             %>
+<%          <Param name="scoreOverride">file=C:/absolute/path/to/rdf-data.n3</Param> - An absolute path to an rdf       %>
+<%              file on a windows operating system                                                                      %>
+<%          <Param name="scoreOverride">file=relative/path/to/rdf-data.ttl</Param> - A path to an rdf file that is      %>
+<%              relative to the folder the shell was in when this command was executed                                  %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  rdfLang - the format of the rdf in the file                                                                         %>
+<%          (optional, only used when type is file)                                                                     %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">rdfLang=RDF/XML</Param> - rdf/xml format                              %>
+<%          <Param name="scoreOverride">rdfLang=N3</Param> - n3 format                                                  %>
+<%          <Param name="scoreOverride">rdfLang=TTL</Param> - turtle/ttl format                                         %>
+<%          <Param name="scoreOverride">rdfLang=N-TRIPLE</Param> - n-triple format                                      %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbLayout - the layout to use for an sdb model                                                                       %>
+<%          (optional, only used when type is sdb)                                                                      %>
+<%      Possible Values:                                                                                                %>
+<%          (default) <Param name="scoreOverride">dbLayout=layout2</Param> - layout2                                    %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbType - the name of the database type (as specified by jena)                                                       %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbType=MySQL</Param> - mysql database                                           %>
+<%          <Param name="scoreOverride">dbType=H2</Param> - h2 database                                                 %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbClass - the JDBC driver class to use                                                                              %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbClass=com.mysql.jdbc.Driver</Param> - mysql database                          %>
+<%          <Param name="scoreOverride">dbClass=org.h2.Driver</Param> - h2 database                                     %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUrl - the JDBC connection url                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:mysql://127.0.0.1:3306/dbName</Param> - mysql database               %>
+<%              see http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-configuration-properties.html          %>
+<%          <Param name="scoreOverride">dbUrl=jdbc:h2:path/to/h2/store</Param> - h2 database                            %>
+<%              see http://www.h2database.com/html/features.html#database_url                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  modelName - the named model to use                                                                                  %>
+<%          (optional, uses default model if not specified, only used when type is rdb, tdb, or sdb )                   %>
+<%      Examples:                                                                                                       %>
+<%          <Param name="scoreOverride">modelName=http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>           %>
+<%          <Param name="scoreOverride">modelName=mySimpleModelName</Param>                                             %>
+<%          <Param name="scoreOverride">modelName=http://vivo.localinstitution.edu/models/my-uri-model</Param>          %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbUser - the DB username to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbUser=sa</Param> - used for h2 database (the default h2 system admin login     %>
+<%          <Param name="scoreOverride">dbUser=myUser</Param>                                                           %>
+<%  ===                                                                                                                 %>
+<%                                                                                                                      %>
+<%  dbPass - the DB password to use                                                                                     %>
+<%          (only needed when type is rdb or sdb)                                                                       %>
+<%      Example:                                                                                                        %>
+<%          <Param name="scoreOverride">dbPass=</Param> - used for h2 database (the default h2 system admin login       %>
+<%          <Param name="scoreOverride">dbPass=myPass</Param>                                                           %>
+<%  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  %>
+-->
+<Model>
+    <Model>
+        <Param name="type">tdb</Param>
+        <Param name="dbDir">/usr/local/vivo/vivo_home/tdbContentModels</Param>
+        <Param name="modelName">http://vitro.mannlib.cornell.edu/default/vitro-kb-2</Param>
+    </Model>
+
+</Model>

--- a/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/xsltranslator.config.xml
+++ b/example-scripts/bash-scripts/full-harvest-examples/1.15-examples/example-pubmed/xsltranslator.config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2010-2011 VIVO Harvester Team. For full list of contributors, please see the AUTHORS file provided.
+  All rights reserved.
+  This program and the accompanying materials are made available under the terms of the new BSD license which accompanies this distribution, and is available at http://www.opensource.org/licenses/bsd-license.html
+-->
+<Task>
+        <Param name="wordiness">INFO</Param>
+	<!--INPUT -->
+	<Param name="input">raw-records.config.xml</Param>
+	
+	<!--OUTPUT -->
+	<Param name="output">translated-records.config.xml</Param>
+
+	<!--DATAMAP -->
+	<Param name="xslFile">pubmed-to-vivo.datamap.xsl</Param>
+</Task>


### PR DESCRIPTION
Added an example of fetching publication metadata from pubmed based on the `pubmed-http-fetch`.

Steps to run:

- Examine the run-pubmed.sh script and type the location of the VIVO Harvester installation directory.
- Modify the vivo.model.xml file to provide parameters for accessing your VIVO web application.
- Modify the `pubmedfetch.config.xml` to point to your desired instance's endpoint, as well as other pubmed properties 
- Shut down your VIVO instance (in order to free the TDB lock)
- Run `run-pubmed.sh`
- Restart your VIVO instance, reindex the search indexes and re-run the reasoner.
